### PR TITLE
create /etc/jupyter and copy config there

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,9 +117,9 @@ RUN pip install --no-cache-dir nbresuse \
   && jupyter serverextension enable --py --system nbresuse \
   && pip install --no-cache-dir \
   --extra-index-url="https://packages.dea.ga.gov.au" \
-  --no-deps --upgrade odc-algo odc-ui 'datacube[performance]' \ 
-  && mkdir -m664 /etc/jupyter
-COPY jupyter_notebook_config.py /etc/jupyter/
+  --no-deps --upgrade odc-algo odc-ui 'datacube[performance]'
+
+COPY --chown=1000:100  jupyter_notebook_config.py /etc/jupyter/
 
 
 COPY with_bootstrap /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,7 @@ RUN pip install --no-cache-dir nbresuse \
   --extra-index-url="https://packages.dea.ga.gov.au" \
   --no-deps --upgrade odc-algo odc-ui 'datacube[performance]' \ 
   && mkdir -m664 /etc/jupyter
-COPY jupyter_notebook_config.py "/etc/jupyter/"
+COPY jupyter_notebook_config.py /etc/jupyter/
 
 
 COPY with_bootstrap /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,7 +117,10 @@ RUN pip install --no-cache-dir nbresuse \
   && jupyter serverextension enable --py --system nbresuse \
   && pip install --no-cache-dir \
   --extra-index-url="https://packages.dea.ga.gov.au" \
-  --no-deps --upgrade odc-algo odc-ui 'datacube[performance]'
+  --no-deps --upgrade odc-algo odc-ui 'datacube[performance]' \ 
+  && mkdir -m664 /etc/jupyter
+COPY jupyter_notebook_config.py "/etc/jupyter/"
+
 
 COPY with_bootstrap /usr/local/bin/
 ENTRYPOINT ["/bin/tini", "-s", "--", "with_bootstrap"]

--- a/docker/jupyter_notebook_config.py
+++ b/docker/jupyter_notebook_config.py
@@ -1,0 +1,3 @@
+# Add docs to iframe extension
+c.JupyterLabIFrame.iframes = ['https://docs.dea.ga.gov.au']
+c.JupyterLabIFrame.welcome = 'https://docs.dea.ga.gov.au'


### PR DESCRIPTION
This change adds default notebook config to the docker image. 

The included config flags are for the iframe extension, but we can use this file to adjust any other config in a readonly manner, without injecting files into the users home dir. 