### PR TITLE
Make master push the current git tag as well as latest

### DIFF
--- a/.github/workflows/docker-sandbox.yml
+++ b/.github/workflows/docker-sandbox.yml
@@ -43,14 +43,17 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Get the Git tag
+      id: get_version
+      run: echo ::set-output name=VERSION::$(git describe --tags)
+
     - name: Build and Push latest Docker image
       uses: whoan/docker-build-with-cache-action@v4
       with:
         image_name: ${{ env.IMAGE_NAME }}
         username: ${{ env.DOCKER_USER }}
         password: "${{ secrets.DockerPassword }}"
-        image_tag: latest
-        # push_git_tag: true
+        image_tag: latest,${{ steps.get_version.outputs.VERSION }}
         context: ./docker
 
     - name: Build and Push latest sudo Docker image
@@ -60,5 +63,5 @@ jobs:
         username: ${{ env.DOCKER_USER }}
         password: "${{ secrets.DockerPassword }}"
         build_extra_args: "--build-arg=WITH_SUDO=yes"
-        image_tag: sudo-latest
+        image_tag: sudo-latest,sudo-${{ steps.get_version.outputs.VERSION }}
         context: ./docker


### PR DESCRIPTION
This will push something like the following:
`v0.0.2-11-gce2ea09`

Which is `<most recent release>-<commits after release>-<git hash?>`.

Thoughts @tom-butler and @Kirill888? 

I like it because it's simple and just comes straight out of `git describe --tags` 