### PR TITLE
Console error fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN echo "Adding jupyter lab extensions" \
   && jupyter labextension install --no-build ipycanvas@v0.3.4 \
   && jupyter labextension install --no-build jupyterlab_iframe@0.2.1 \
   && jupyter lab build \
-  && jupyter serverextension enable --py jupyterlab_code_formatter \
+  && jupyter serverextension enable --py jupyterlab_code_formatter --sys-prefix \
   && jupyter serverextension enable --py --system jupyterlab_iframe \
   && jupyter labextension list \
   && echo "...done"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -54,12 +54,12 @@ urbanaccess
 # jupyter things
 jupyter==1.0.0
 jupyterlab==1.2.3
-jupyterhub==0.9.6
+jupyterhub==1.1.0
 ipyleaflet==0.11.1
 jupyter-server-proxy==1.1.0
 dask-labextension==1.0.3
 nbdime==1.1.0
-jupyterlab_code_formatter==0.5.0
+jupyterlab-code-formatter==0.5.0
 sidecar==0.3.0
 ipyevents==0.7.0
 ipycanvas==0.3.4

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -53,13 +53,13 @@ urbanaccess
 
 # jupyter things
 jupyter==1.0.0
-jupyterlab==1.0.9
+jupyterlab==1.2.3
 jupyterhub==0.9.6
 ipyleaflet==0.11.1
 jupyter-server-proxy==1.1.0
 dask-labextension==1.0.3
 nbdime==1.1.0
-jupyterlab-code-formatter==0.5.0
+jupyterlab_code_formatter==0.5.0
 sidecar==0.3.0
 ipyevents==0.7.0
 ipycanvas==0.3.4


### PR DESCRIPTION
Change `jupyterlab` base version to 1.2.3 - tested compatability with `jupyterlab-git`
Changer `jupyterlab-code-formatter` to `jupyter_code_fomatter` as per official doc
https://jupyterlab-code-formatter.readthedocs.io/en/latest/index.html

```
jupyter labextension install @ryantam626/jupyterlab_code_formatter
pip install jupyterlab_code_formatter
jupyter serverextension enable --py jupyterlab_code_formatter
```