### PR TITLE
Push git derived tags from master to sandbox-dev instead

### DIFF
--- a/.github/workflows/bin/ci-helper
+++ b/.github/workflows/bin/ci-helper
@@ -37,7 +37,8 @@ export_cfg () {
     im_latest=${ORG}/${IMAGE}:latest
     im_stage2_fallback=${im_latest}
     im_stage1_fallback=${ORG}/${IMAGE_DEV}:master_stage1
-    extra_tag=""  # only set on master
+    im_extra=""  # only set on master
+    im_sudo_extra=""  # only set on master
     build_info="$(date -Im) $sha"
 
     case "${ref}" in
@@ -48,7 +49,9 @@ export_cfg () {
             im_sudo=${ORG}/${IMAGE}:sudo-latest
             # figure out extra tag
             git fetch --prune --unshallow 2> /dev/null || true
-            extra_tag=$(git describe --tags)
+            vv=$(git describe --tags)
+            im_extra="${ORG}/${IMAGE_DEV}:${vv}"
+            im_sudo_extra="${ORG}/${IMAGE_DEV}:sudo-${vv}"
             ;;
         "refs/heads/"*)
             BRANCH="${ref#refs/heads/}"
@@ -78,7 +81,6 @@ export_cfg () {
 
     im_stage1=${ORG}/${IMAGE_DEV}:${BRANCH}_stage1
     all_envs='BRANCH
-      extra_tag
       pull_cache
       push_cache
       push_image
@@ -86,6 +88,8 @@ export_cfg () {
       im_stage2 im_stage2_fallback
       im_sudo
       im_latest
+      im_extra
+      im_sudo_extra
       build_info'
 
     for x in $all_envs; do

--- a/.github/workflows/docker-sandbox-cache.yml
+++ b/.github/workflows/docker-sandbox-cache.yml
@@ -117,11 +117,8 @@ jobs:
     - name: Push Extra tags (master branch only)
       if: github.ref == 'refs/heads/master' && steps.cfg.outputs.push_image == 'yes'
       run: |
-        im_stage2_extra="${im_stage2%:latest}:${extra_tag}"
-        im_sudo_extra="${im_sudo%:sudo-latest}:sudo-${extra_tag}"
-
-        docker tag "${im_stage2}" "${im_stage2_extra}"
+        docker tag "${im_stage2}" "${im_extra}"
         docker tag "${im_sudo}" "${im_sudo_extra}"
 
-        docker push "${im_stage2_extra}"
+        docker push "${im_extra}"
         docker push "${im_sudo_extra}"


### PR DESCRIPTION
When building on master push final result to

- `{org}/{image}:latest`
- `{org}/{image-dev}:{git-tag}`
- `{org}/{image}:sudo-latest`
- `{org}/{image-dev}:sudo-{git-tag}`