### PR TITLE
Simplify export_cfg: do not set sudo images names

### DIFF
--- a/.github/workflows/bin/ci-helper
+++ b/.github/workflows/bin/ci-helper
@@ -38,7 +38,6 @@ export_cfg () {
     im_stage2_fallback=${im_latest}
     im_stage1_fallback=${ORG}/${IMAGE_DEV}:master_stage1
     im_extra=""  # only set on master
-    im_sudo_extra=""  # only set on master
     build_info="$(date -Im) $sha"
 
     case "${ref}" in
@@ -46,23 +45,19 @@ export_cfg () {
             BRANCH="master"
             im_stage2=${im_latest}
             im_stage2_fallback=""
-            im_sudo=${ORG}/${IMAGE}:sudo-latest
             # figure out extra tag
             git fetch --prune --unshallow 2> /dev/null || true
             vv=$(git describe --tags)
             im_extra="${ORG}/${IMAGE_DEV}:${vv}"
-            im_sudo_extra="${ORG}/${IMAGE_DEV}:sudo-${vv}"
             ;;
         "refs/heads/"*)
             BRANCH="${ref#refs/heads/}"
             im_stage2=${ORG}/${IMAGE_DEV}:${BRANCH}
-            im_sudo=${ORG}/${IMAGE_DEV}:sudo-${BRANCH}
             ;;
         "refs/tags/"*)
             push_cache="no"
             BRANCH="${ref#refs/tags/}"
             im_stage2=${ORG}/${IMAGE}:${BRANCH}
-            im_sudo=${ORG}/${IMAGE}:sudo-${BRANCH}
             ;;
         "refs/pull/"*)
             if [ -z "${GITHUB_HEAD_REF:-}" ] ; then
@@ -72,7 +67,6 @@ export_cfg () {
             push_image="no"
             BRANCH="${GITHUB_HEAD_REF}"
             im_stage2=${ORG}/${IMAGE_DEV}:${BRANCH}
-            im_sudo=${ORG}/${IMAGE_DEV}:sudo-${BRANCH}
             ;;
         *)
             return 1
@@ -86,10 +80,8 @@ export_cfg () {
       push_image
       im_stage1 im_stage1_fallback
       im_stage2 im_stage2_fallback
-      im_sudo
       im_latest
       im_extra
-      im_sudo_extra
       build_info'
 
     for x in $all_envs; do

--- a/.github/workflows/docker-sandbox-cache.yml
+++ b/.github/workflows/docker-sandbox-cache.yml
@@ -39,7 +39,6 @@ jobs:
         echo branch: ${BRANCH}
         echo stage1: ${im_stage1} ${im_stage1_fallback}
         echo stage2: ${im_stage2} ${im_stage2_fallback}
-        echo sudo:   ${im_sudo}
         echo build_info: ${build_info}
         echo push_image: cfg:${{ steps.cfg.outputs.push_image }} env:$push_image
         echo push_cache: cfg:${{ steps.cfg.outputs.push_cache }} env:$push_cache
@@ -119,6 +118,7 @@ jobs:
 
     - name: Build Sandbox Docker (sudo)
       run: |
+        im_sudo=${im_stage2/:/:sudo-}
         docker build \
           --build-arg WITH_SUDO=yes \
           --build-arg BUILD_INFO="${build_info} (sudo)" \
@@ -130,12 +130,15 @@ jobs:
     - name: DockerHub Push Image (sudo)
       if: steps.cfg.outputs.push_image == 'yes'
       run: |
+        im_sudo=${im_stage2/:/:sudo-}
         docker push ${im_sudo}
 
 
     - name: Push Extra tags (master branch only)
       if: github.ref == 'refs/heads/master' && steps.cfg.outputs.push_image == 'yes'
       run: |
+        im_sudo=${im_stage2/:/:sudo-}
+        im_sudo_extra=${im_extra/:/:sudo-}
         docker tag "${im_stage2}" "${im_extra}"
         docker tag "${im_sudo}" "${im_sudo_extra}"
 


### PR DESCRIPTION
export_cfg is no longer aware of "sudo" images, these can be trivially computed
by replacing `:` with `:sudo-` if and when they are needed.