### PR TITLE
Fix labextension build and address issue 11

### DIFF
--- a/.github/workflows/bin/ci-helper
+++ b/.github/workflows/bin/ci-helper
@@ -38,7 +38,7 @@ export_cfg () {
     im_stage2_fallback=${im_latest}
     im_stage1_fallback=${ORG}/${IMAGE_DEV}:master_stage1
     im_extra=""  # only set on master
-    build_info="$(date -Im) $sha"
+    build_info="$(TZ=Australia/Sydney date -Im) $sha"
 
     case "${ref}" in
         "refs/heads/master")

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,12 @@ COPY jupyter-extensions.txt /conf/
 # TAB_NAME -- name to appear in the browser tab
 ARG TAB_NAME="DEA Sandbox"
 RUN echo "Adding jupyter lab extensions" \
-  xargs -n1 jupyter labextension install --no-build < /conf/jupyter-extensions.txt \
+  && while read ext; do \
+      if [ -n "${ext}" ]; then \
+        echo "Installing ${ext}"; \
+        jupyter labextension install --no-build "${ext}"; \
+      fi; \
+     done < /conf/jupyter-extensions.txt \
   && jupyter lab build --name="${TAB_NAME}" \
   && jupyter lab clean \
   && jupyter labextension list \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,8 +109,6 @@ RUN echo "Enable server extensions" \
 #   --extra-index-url="https://packages.dea.ga.gov.au" \
 #   --no-deps --upgrade odc-algo odc-ui 'datacube[performance,s3]'
 
-COPY --chown=1000:100  jupyter_notebook_config.py /etc/jupyter/
-
 COPY sync_repo with_bootstrap /usr/local/bin/
 ENTRYPOINT ["/bin/tini", "-s", "--", "with_bootstrap"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,9 +23,11 @@ RUN echo "Building python environment: stage Jupyter" \
   && env-build-tool extend /conf/requirements-jupyter.txt ${py_env_path}
 
 COPY jupyter-extensions.txt /conf/
+# TAB_NAME -- name to appear in the browser tab
+ARG TAB_NAME="DEA Sandbox"
 RUN echo "Adding jupyter lab extensions" \
   xargs -n1 jupyter labextension install --no-build < /conf/jupyter-extensions.txt \
-  && jupyter lab build \
+  && jupyter lab build --name="${TAB_NAME}" \
   && jupyter lab clean \
   && jupyter labextension list \
   && echo "...done"

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,9 +11,13 @@ Sandbox Docker
 
 ### Extending
 
-For large changes add new libraries to `requirements.txt`. There are several
-"logical clusters" of packages in there, try to attach new package to a correct
-group or create new category if needed.
+For large changes add new libraries to `requirements.txt` or
+`requirements-jupyter.txt`. There are several "logical clusters" of packages in
+there, try to attach new package to a correct group or create new category if
+needed.
+
+To add a new jupyter lab extension edit `jupyter-extensions.txt`. Always pin
+extensions and Python libraries that use them.
 
 Modifying `requirements.txt` will trigger a complete rebuild of the python
 environment and docker image. This is not always desirable. If you just need to

--- a/docker/jupyter_notebook_config.py
+++ b/docker/jupyter_notebook_config.py
@@ -1,3 +1,0 @@
-# Add docs to iframe extension
-c.JupyterLabIFrame.iframes = ['https://docs.dea.ga.gov.au']
-c.JupyterLabIFrame.welcome = 'https://docs.dea.ga.gov.au'


### PR DESCRIPTION
1. Stupid docker and it's "one line craziness", missing `&&` caused non-failing skipping of lab extension installation.
2. Add `TAB_NAME` argument with default being `DEA Sandbox`
3. Removed jupyter config file which is now in deployment config
4. Build info timestamp is now in Sydney time zone

Closes #11 