### PR TITLE
Make sure latest datacube library is installed

### DIFF
--- a/docker/requirements-jupyter.txt
+++ b/docker/requirements-jupyter.txt
@@ -5,19 +5,18 @@ jupyterlab_iframe==0.2.1
 jupyterhub==1.1.0
 ipyleaflet==0.11.1
 jupyter-server-proxy==1.3.2
-dask-labextension==1.0.3
 nbdime==1.1.0
 jupyterlab-code-formatter==0.5.0
 sidecar==0.3.0
 ipyevents==0.7.0
 ipycanvas==0.3.4
-jupyter-bokeh==1.1.1
+ipyfilechooser
 jupyterlab-git
+nbgitpuller
 jupyter-nbextensions-configurator
 jupyter-contrib-nbextensions
 jupyter-contrib-core
 jupyter-ui-poll
-nbgitpuller
 nbresuse
 black
 autopep8
@@ -30,16 +29,21 @@ nbval
 
 # jupyter + matplotlib
 matplotlib
-bokeh==1.4.0
 descartes
 ipympl==0.5.6
-datashader
 graphviz
 folium
-geoviews
-holoviews
-cartopy
 seaborn
-ipyfilechooser
 pydotplus
 plotly
+
+# jupyter + bokeh
+# bokeh==1.4.0 is pinned in requirements.txt because of dask
+#
+jupyter-bokeh==1.1.1
+dask-labextension==1.0.3
+geoviews==1.7.0
+cartopy==0.17.0
+datashader==0.10.0
+panel==0.8.0
+holoviews==1.13.2

--- a/docker/requirements-jupyter.txt
+++ b/docker/requirements-jupyter.txt
@@ -29,11 +29,9 @@ nbval
 
 # jupyter + matplotlib
 # matplotlib itself is in requirements.txt as it's pulled in by other libs there
-descartes
 ipympl==0.5.6
 graphviz
 folium
-seaborn
 pydotplus
 plotly
 

--- a/docker/requirements-jupyter.txt
+++ b/docker/requirements-jupyter.txt
@@ -28,7 +28,7 @@ nbformat
 nbval
 
 # jupyter + matplotlib
-matplotlib
+# matplotlib itself is in requirements.txt as it's pulled in by other libs there
 descartes
 ipympl==0.5.6
 graphviz

--- a/docker/requirements-odc.txt
+++ b/docker/requirements-odc.txt
@@ -1,5 +1,6 @@
 # ODC/DEA
 --extra-index-url="https://packages.dea.ga.gov.au"
+--pre
 datacube[performance,s3]
 odc_algo
 odc_ui

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -64,6 +64,7 @@ pysal
 pyepsg
 mapclassify
 urbanaccess
+pysheds
 
 --no-binary=aiohttp\
 ,cffi\

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -7,14 +7,26 @@ cython
 ruamel.yaml
 ruamel.yaml.clib
 pyrsistent
-ciso8601
-psycopg2
 param
 dill
 ffmpeg-python
 tqdm
 voluptuous
 pydash
+# pre-install misc datacube dependencies
+jsonschema
+ciso8601
+psycopg2
+sqlalchemy
+toolz
+lark-parser
+setuptools_scm[toml]
+bottleneck
+# pre-install misc odc-tools dependencies
+lmdb
+zstandard
+thredds-crawler
+astropy
 
 # Scientific Stack
 numpy
@@ -58,6 +70,7 @@ urbanaccess
 ,cftime\
 ,cryptography\
 ,lxml\
+,lmdb\
 ,numexpr\
 ,numexpr3\
 ,protobuf\
@@ -70,3 +83,4 @@ urbanaccess
 ,statsmodels\
 ,typed_ast\
 ,tables\
+,zstandard\

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -48,6 +48,8 @@ tensorflow
 ### plotting
 bokeh==1.4.0
 matplotlib==3.2.1
+descartes
+seaborn
 
 # Geo stack
 geojson

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -44,6 +44,8 @@ dask[complete]==2.8.1
 distributed==2.8.1
 xarray
 tensorflow
+### plotting
+bokeh==1.4.0
 
 # Geo stack
 geojson

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -27,6 +27,7 @@ lmdb
 zstandard
 thredds-crawler
 astropy
+boltons
 
 # Scientific Stack
 numpy

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -47,6 +47,7 @@ xarray
 tensorflow
 ### plotting
 bokeh==1.4.0
+matplotlib==3.2.1
 
 # Geo stack
 geojson


### PR DESCRIPTION
Datacube lib version was stuck at `1.7+262.g1cf3cea8` before this change. Switching to `setuptools_scm` changed the version number to be more proper, and now `--pre` option (allow pre-release install) is needed to install latest datacube `1.8.0b7.dev13+g183257f1` from our packages repo.

Also in this PR:
- install more of the datacube and odc-tools dependencies upfront
- Add `pysheds` library (#69)
 