### PR TITLE
datacube==1.8.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,17 @@ RUN echo "Adding odc-dependencies" \
 
 FROM opendatacube/geobase:runner${V_BASE}
 
+#Install ffmpeg static binary
+RUN apt-get update -y \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
+  xz-utils \
+  curl \
+  && curl -s -L https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.1.4-amd64-static.tar.xz > ffmpeg.tar.xz \
+  && echo "546b9eb4517f4f5278356dfa125e08f95829b00282331d23f0c60241955b99c2" ffmpeg.tar.xz | sha256sum -c - \
+  && tar xvJ --strip-components=1 -C /tmp < ffmpeg.tar.xz \
+  && mv /tmp/ffmpeg /usr/local/bin/ffmpeg \
+  && rm -rf /tmp/* ffmpeg.tar.xz
+
 RUN apt-get update -y \
 && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
   # developer convenience
@@ -85,13 +96,6 @@ RUN apt-get update -y \
   libfftw3-dev \
   liblapack-dev \
 && rm -rf /var/lib/apt/lists/*
-
-#Install ffmpeg static binary
-RUN curl -s -L https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.1.4-amd64-static.tar.xz > ffmpeg.tar.xz \
-  && echo "546b9eb4517f4f5278356dfa125e08f95829b00282331d23f0c60241955b99c2" ffmpeg.tar.xz | sha256sum -c - \
-  && tar xvJ --strip-components=1 -C /tmp < ffmpeg.tar.xz \
-  && mv /tmp/ffmpeg /usr/local/bin/ffmpeg \
-  && rm -rf /tmp/* ffmpeg.tar.xz
 
 # Install Tini
 COPY --from=env_builder /bin/tini /bin/tini

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get update -y \
   fish \
   tig \
   git \
+  jq \
   xz-utils \
   openssh-client \
   graphviz \

--- a/docker/requirements-odc.txt
+++ b/docker/requirements-odc.txt
@@ -1,7 +1,6 @@
 # ODC/DEA
 --extra-index-url="https://packages.dea.ga.gov.au"
---pre
-datacube[performance,s3]
+datacube[performance,s3]==1.8.0
 odc_algo
 odc_ui
 odc_index


### PR DESCRIPTION
- Pin `datacube` to 1.8.0
- add `jq` for developer convenience
- Reshuffle install order a bit (install ffmpeg before other things, as this is least changing step)
