### PR TITLE
Disable extensions manager

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,6 +123,7 @@ ENV PATH=/usr/local/bin:${py_env_path}/bin:$PATH
 #   --no-deps --upgrade odc-algo odc-ui 'datacube[performance,s3]'
 
 COPY assets/sync_repo assets/with_bootstrap assets/jupyterhub-singleuser /usr/local/bin/
+COPY assets/overrides.json $py_env_path/share/jupyter/lab/settings/
 
 WORKDIR "/home/$nb_user"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,10 +124,6 @@ ENV PATH=/usr/local/bin:${py_env_path}/bin:$PATH
 
 COPY assets/sync_repo assets/with_bootstrap assets/jupyterhub-singleuser /usr/local/bin/
 
-# TODO: get rid of line below when spawner is updated to launch jupyter-lab instead of -labhub
-COPY assets/jupyterhub-singleuser /usr/local/bin/jupyter-labhub
-
-
 WORKDIR "/home/$nb_user"
 
 ARG WITH_SUDO="no"

--- a/docker/assets/overrides.json
+++ b/docker/assets/overrides.json
@@ -1,0 +1,3 @@
+{
+  "@jupyterlab/extensionmanager-extension:plugin":{"enabled":false}
+}


### PR DESCRIPTION
We do not include npm/node in the image so new packages can not be installed
anyway, and plugin crashes when npm is not present.