### PR TITLE
Install fractional cover lib in binary mode

### DIFF
--- a/docker/requirements-odc.txt
+++ b/docker/requirements-odc.txt
@@ -2,6 +2,7 @@
 --extra-index-url="https://packages.dea.ga.gov.au"
 datacube[performance,s3]==1.8.1
 datacube-stats
+fc
 odc_algo
 odc_ui
 odc_index


### PR DESCRIPTION
1. `fc` pulls in `datacube` so needs to be installed with or after `datacube`
2. We don't have correctly working source distribution of `fc` because of some issues with automatic versioning from git code which will take some time to sort out.