### PR TITLE
Pull latest datacube build from packages.dea.ga.gov.au

### DIFF
--- a/docker/requirements-odc.txt
+++ b/docker/requirements-odc.txt
@@ -1,6 +1,6 @@
 # ODC/DEA: frequently changing
 --extra-index-url="https://packages.dea.ga.gov.au"
-datacube[performance,s3]==1.8.1
+datacube[performance,s3]
 datacube-stats
 fc
 odc_algo

--- a/docker/requirements-odc.txt
+++ b/docker/requirements-odc.txt
@@ -1,6 +1,6 @@
 # ODC/DEA: frequently changing
 --extra-index-url="https://packages.dea.ga.gov.au"
-datacube[performance,s3]
+datacube[performance,s3]>=1.8.2.dev
 datacube-stats
 fc
 odc_algo


### PR DESCRIPTION
need some fixes from unreleased version.