### PR TITLE
Adding jupyterlab code snippets extension

### DIFF
--- a/docker/jupyter-extensions.txt
+++ b/docker/jupyter-extensions.txt
@@ -6,3 +6,4 @@ jupyter-matplotlib@v0.7.2
 @bokeh/jupyter_bokeh@2.0.2
 @ryantam626/jupyterlab_code_formatter@v1.3.6
 jupyterlab-jupytext@v1.2.1
+jupyterlab-code-snippets@v1.0.4


### PR DESCRIPTION
Extension provides snippet management capability, user can define snippets then inject them into notebook. Useful for things like matplotlib/autoreload/dask setup things that are often duplicated across notebooks.