### PR TITLE
Move hdstats installation into frequently changing for now

### DIFF
--- a/docker/requirements-odc-static.txt
+++ b/docker/requirements-odc-static.txt
@@ -1,7 +1,6 @@
 # ODC/DEA: these are installed in builder stage
 --extra-index-url="https://packages.dea.ga.gov.au"
 otps>=0.3.1
-hdstats>=0.1.7.post5
 hdmedians
 
 eodatasets3
@@ -15,5 +14,4 @@ rsgislib
 s2cloudmask
 
 --no-binary=\
-,hdstats\
 ,hdmedians

--- a/docker/requirements-odc.txt
+++ b/docker/requirements-odc.txt
@@ -17,3 +17,4 @@ odc_dtools
 odc_stats
 odc-apps-dc-tools
 odc-apps-cloud
+hdstats>=0.1.8.post1 --no-binary=hdstats


### PR DESCRIPTION
We do have Cython and compilers in runner stage anyway, so might as well avoid
changing builder stage every time hdstats is bumped