### PR TITLE
jupyterhub version upgrade to 1.3.0

### DIFF
--- a/docker/jupyter-extensions.txt
+++ b/docker/jupyter-extensions.txt
@@ -1,6 +1,6 @@
 @jupyter-widgets/jupyterlab-manager@v2.0.0
 @jupyterlab/geojson-extension@v2.0.1
-@jupyterlab/hub-extension@v2.1.2
+@jupyterlab/hub-extension@v3.0.5
 @jupyterlab/toc@v4.0.0
 dask-labextension@v2.0.2
 jupyter-matplotlib@v0.7.2

--- a/docker/requirements-jupyter.txt
+++ b/docker/requirements-jupyter.txt
@@ -2,7 +2,7 @@
 jupyter==1.0.0
 jupyterlab==2.2.9
 jupyterlab_iframe==0.2.2
-jupyterhub==1.1.0
+jupyterhub==1.3.0
 ipywidgets==7.5.1
 ipyleaflet==0.13.0
 jupyter-server-proxy==1.5.0


### PR DESCRIPTION
as part of jupyterhub upgrade, we need to upgrade `jupyterhub` version to `1.3.0`