### PR TITLE
Escape all / in branch name when constructing tag

### DIFF
--- a/.github/workflows/bin/ci-helper
+++ b/.github/workflows/bin/ci-helper
@@ -28,6 +28,10 @@ branch_name () {
     esac
 }
 
+safe_tag_name () {
+    echo ${1//\//_}
+}
+
 export_cfg () {
     local ref="${1:-${GITHUB_REF:-}}"
     local sha="${2:-${GITHUB_SHA:-missing_sha}}"
@@ -53,14 +57,12 @@ export_cfg () {
             im_extra="${ORG}/${IMAGE_DEV}:${vv}"
             ;;
         "refs/heads/"*)
-            BRANCH="${ref#refs/heads/}"
-            BRANCH="${BRANCH/\//_}"
+            BRANCH=$(safe_tag_name "${ref#refs/heads/}")
             im_stage2=${ORG}/${IMAGE_DEV}:${BRANCH}
             ;;
         "refs/tags/"*)
             push_cache="no"
-            BRANCH="${ref#refs/tags/}"
-            BRANCH="${BRANCH/\//_}"
+            BRANCH=$(safe_tag_name "${ref#refs/tags/}")
             im_stage2=${ORG}/${IMAGE}:${BRANCH}
             ;;
         "refs/pull/"*)
@@ -69,8 +71,7 @@ export_cfg () {
             fi
             push_cache="no"
             push_image="no"
-            BRANCH="${GITHUB_HEAD_REF}"
-            BRANCH="${BRANCH/\//_}"
+            BRANCH=$(safe_tag_name "${GITHUB_HEAD_REF}")
             im_stage2=${ORG}/${IMAGE_DEV}:${BRANCH}
             ;;
         *)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,20 +49,21 @@ RUN echo "Adding odc-dependencies (static)" \
 
 FROM opendatacube/geobase:runner${V_BASE}
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 #Install ffmpeg static binary
 RUN apt-get update -y \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
-  xz-utils \
-  curl \
+  && apt-get install -y --fix-missing --no-install-recommends xz-utils curl \
   && rm -rf /var/lib/apt/lists/* \
   && curl -s -L https://www.johnvansickle.com/ffmpeg/old-releases/ffmpeg-4.2.2-amd64-static.tar.xz > ffmpeg.tar.xz \
   && echo "c1c7ec5180523db214a7f6f59ea737e8e582570cb884c3ab0c583da4f5165e27" ffmpeg.tar.xz | sha256sum -c - \
   && tar xvJ --strip-components=1 -C /tmp < ffmpeg.tar.xz \
+  && mkdir -p /usr/local/bin/ \
   && mv /tmp/ffmpeg /usr/local/bin/ffmpeg \
   && rm -rf /tmp/* ffmpeg.tar.xz
 
 RUN apt-get update -y \
-&& DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \
+&& apt-get install -y --fix-missing --no-install-recommends \
   # developer convenience
   postgresql-client-10 \
   postgresql-10 \

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -79,7 +79,7 @@ h5py
 netcdf4
 rtree
 pandana
-pysal
+pysal==2.3.0
 pyepsg
 mapclassify
 urbanaccess


### PR DESCRIPTION
Correct error in constructing tag from branch name, need to replace all `/` not just first one like previously.

Also had to pin pysal as new one doesn't work on Python 3.6 anymore.