### PR TITLE
Try to maybe fix opencv?

### DIFF
--- a/docker/requirements-odc-static.txt
+++ b/docker/requirements-odc-static.txt
@@ -13,5 +13,9 @@ rsgislib
 #  https://github.com/daleroberts/s2cloudmask
 s2cloudmask
 
+# need to be installed after to override libs with non-gl ones
+opencv-python-headless
+opencv-contrib-python-headless
+
 --no-binary=\
 ,hdmedians

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -38,8 +38,6 @@ structlog
 # Scientific Stack
 dask[complete]==2.30.0
 distributed==2.30.0
-opencv-python-headless
-opencv-contrib-python-headless
 dask-image
 dask-ml
 tensorflow==2.3.1


### PR DESCRIPTION
my understanding is that opencv-headless simply ships binaries compiled without
GL dependencies, so it needs to be installed after installation of non-headless
version which is pulled in by one of the dependencies we have. binary world of
pip is messed up, but compiling this from source is not something I would do
with the current setup.