### PR TITLE
Installed Tools folder on notebook sync

### DIFF
--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -3,6 +3,9 @@
 REPO=$1
 BRANCH="${2:-master}"
 
+REPO_NAME=$(basename -- "$REPO")
+REPO_DIR="${REPO_NAME%.*}"
+
 # Don't sync if there's a .no_sync file
 [ -e .no_sync  ] || {
     # Sync notebook repo
@@ -15,4 +18,6 @@ BRANCH="${2:-master}"
     rm -rf "${WORKDIR}"/{.git,.github,.gitignore,LICENSE,README.md,DEAfrica_notebooks_template.ipynb} || true
     rsync --verbose --recursive "${WORKDIR}/" ~/
     rm -rf "${WORKDIR}"
+    # Install Tools folder if available
+    pip install -e REPO_DIR/Tools || true
 }

--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -19,5 +19,5 @@ REPO_DIR="${REPO_NAME%.*}"
     rsync --verbose --recursive "${WORKDIR}/" ~/
     rm -rf "${WORKDIR}"
     # Install Tools folder if available
-    pip install -e REPO_DIR/Tools || true
+    python -m pip install -e "${REPO_DIR}/Tools" || true
 }


### PR DESCRIPTION
This change installs the Tools folder of a notebooks repo, if available, with pip. dea-notebooks/Tools is available on the stable branch, and a similar effort is underway in deafrica-sandbox-notebooks: https://github.com/digitalearthafrica/deafrica-sandbox-notebooks/tree/minty-fresh-sandbox

Ping @whatnick @cbur24