### PR TITLE
Remove additional DEA Notebooks files from synced files

### DIFF
--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -12,7 +12,7 @@ BRANCH="${2:-master}"
     until $(git clone --depth 1 --branch "$BRANCH" "$REPO" "$WORKDIR") ||  [ $NEXT_WAIT_TIME -eq 4 ]; do
       sleep $(( NEXT_WAIT_TIME++ ))
     done
-    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,DEAfrica_notebooks_template.ipynb} || true
+    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,CITATION.cff,USAGE.rst,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb} || true
     rsync --verbose --recursive "${WORKDIR}/" ~/
     rm -rf "${WORKDIR}"
     # Install Tools folder if available


### PR DESCRIPTION
This PR adds the following files to those that are removed from the main Sandbox file browser. This includes the DEA template notebook (equivalent to the DE Africa one that is already removed):

> DEA_notebooks_template.ipynb

And new citation and usage docs that we do not need to expose to users in the Sandbox:

> CITATION.cff
> USAGE.rst