### PR TITLE
Remove Scientific_workflows and Tests from Sandbox sync

### DIFF
--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -12,7 +12,7 @@ BRANCH="${2:-master}"
     until $(git clone --depth 1 --branch "$BRANCH" "$REPO" "$WORKDIR") ||  [ $NEXT_WAIT_TIME -eq 4 ]; do
       sleep $(( NEXT_WAIT_TIME++ ))
     done
-    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,CITATION.cff,USAGE.rst,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb} || true
+    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
     rsync --verbose --recursive "${WORKDIR}/" ~/
     rm -rf "${WORKDIR}"
     # Install Tools folder if available


### PR DESCRIPTION
This PR closes #195 and #100 by adding the `Scientific_workflows` folder to the list of items to be removed before syncing DEA Notebooks content to the home directory of the DEA Sandbox. This will ensure that beginner users are not exposed to experimental or broken code.

In preparation for the addition of automated tests in `dea-notebooks`, this PR also removes the `Tests` directory ([see here](https://github.com/GeoscienceAustralia/dea-notebooks/tree/develop/Tests/)) from the automatic sync so that this is also not exposed to users.

Finally, this PR also adds `README.rst` in addition to `README.md` to account for the different file formats used in DEA and DE Africa.

Please let me know if there's a better way to achieve this!