### PR TITLE
Remove further files from DEA Notebooks clone to avoid them being exposed to beginner users

### DIFF
--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -12,7 +12,7 @@ BRANCH="${2:-master}"
     until $(git clone --depth 1 --branch "$BRANCH" "$REPO" "$WORKDIR") ||  [ $NEXT_WAIT_TIME -eq 4 ]; do
       sleep $(( NEXT_WAIT_TIME++ ))
     done
-    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
+    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,docker-compose.yml,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
     rsync --verbose --recursive "${WORKDIR}/" ~/
     rm -rf "${WORKDIR}"
     # Install Tools folder if available


### PR DESCRIPTION
Recent changes to the DEA Notebooks repository added a "docker-compose.yml" file to the top level of the reposity. We do not want this file synced to the Sandbox as it will be confusing to beginner users. 

https://github.com/GeoscienceAustralia/dea-notebooks/blob/develop/docker-compose.yml

This PR adds "docker-compose.yml" to the list of files that are removed before cloned files are synced to the Sandbox.