### PR TITLE
Update jupyter-ui-poll to version 0.2.0 

### DIFF
--- a/docker/constraints-jupyter.txt
+++ b/docker/constraints-jupyter.txt
@@ -18,7 +18,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-resource-usage==0.6.0
 jupyter-server==1.10.2
 jupyter-server-proxy==3.1.0
-jupyter-ui-poll==0.1.2
+jupyter-ui-poll==0.2.0
 ipycanvas==0.9.0
 ipyevents==2.0.1
 ipyfilechooser==0.4.4

--- a/docker/requirements-jupyter.txt
+++ b/docker/requirements-jupyter.txt
@@ -21,7 +21,7 @@ jupyter-nbextensions-configurator==0.4.1
 jupyter-resource-usage==0.6.0
 jupyter-server==1.10.2
 jupyter-server-proxy==3.1.0
-jupyter-ui-poll==0.1.2
+jupyter-ui-poll==0.2.0
 ipycanvas==0.9.0
 ipyevents==2.0.1
 ipyfilechooser==0.4.4


### PR DESCRIPTION
This update fixes the following error that currently occurs in JupyterLab 3.0 when attempting to run interactive map selection widgets:

```
/env/lib/python3.8/site-packages/jupyter_ui_poll/_poll.py:52: RuntimeWarning: coroutine 'Kernel.do_one_iteration' was never awaited
  kernel.do_one_iteration()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```