### PR TITLE
Upgrade JupyterLab to version 3.1.12 to close #203

### DIFF
--- a/docker/constraints-jupyter.txt
+++ b/docker/constraints-jupyter.txt
@@ -3,7 +3,7 @@ autopep8==1.5.7
 black==21.6b0
 cognitojwt==1.4.1
 jupyter==1.0.0
-jupyterlab==3.1.7
+jupyterlab==3.1.12
 jupyterlab-code-formatter==1.4.10
 jupyterlab-code-snippets==2.1.0
 jupyterlab-geojson==3.1.2

--- a/docker/requirements-jupyter.txt
+++ b/docker/requirements-jupyter.txt
@@ -3,7 +3,7 @@ autopep8==1.5.7
 black==21.6b0
 cognitojwt==1.4.1 # Used for user authentication
 jupyter==1.0.0
-jupyterlab==3.1.7
+jupyterlab==3.1.12
 jupyterlab-code-formatter==1.4.10
 jupyterlab-code-snippets==2.1.0
 jupyterlab-geojson==3.1.2


### PR DESCRIPTION
This PR bumps the version of JupyterLab to 3.1.12 to avoid the horizontal line and skipped cells issues mentioned in #203.

I'm not sure if this is all I need to do here, so please point me in the right direction if I've missed anything.