### PR TITLE
Update geopandas and pandas versions to close #207

### DIFF
--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -43,7 +43,7 @@ dask-ml==1.9.0
 numba==0.54.0
 numexpr==2.7.3
 numexpr3==3.0.1a6
-pandas==1.3.3
+pandas==1.3.4
 pathos==0.2.8
 Pillow==8.3.2
 scikit-image==0.18.3
@@ -85,7 +85,7 @@ cffi==1.14.6
 cftime==1.5.1
 cryptography==3.4.8
 fiona==1.8.20
-geopandas==0.10.0
+geopandas==0.10.2
 GDAL==3.3.0 # Needs to be same as base image
 lmdb==1.2.1
 lxml==4.6.3


### PR DESCRIPTION
The Sandbox currently uses `geopandas==0.10.0` and `pandas==1.3.3`. These versions include two regressions that cause errors and silent failures when using the `geopandas.union` functionality:
https://geopandas.org/en/stable/docs/changelog.html#version-0-10-2-october-16-2021
https://pandas.pydata.org/docs/whatsnew/v1.3.4.html#fixed-regressions

These PR fixes these regressions by upgrading to `geopandas==0.10.2` and `pandas==1.3.4`.