### PR TITLE
Update `xarray` to latest version 0.21.1

### DIFF
--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -52,8 +52,9 @@ scikit-learn==1.0
 scipy==1.7.1
 tensorflow==2.7.0
 xgboost==1.4.2
-xarray==0.19.0
+xarray==0.21.1
 zarr==2.10.1
+
 ### plotting
 bokeh==2.4.2
 descartes==1.1.0


### PR DESCRIPTION
The current version 0.19.0 of `xarray` has a regression which breaks median computations on Dask arrays.

This is fixed in the latest version of `xarray`. This version also contains ~ 2 years of new features which will be valuable for future work.