### PR TITLE
Add `contextily` Python package

### DIFF
--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -80,6 +80,7 @@ rioxarray==0.8.0
 rio-cogeo==3.0.1
 Rtree==0.9.7
 urbanaccess==0.2.2
+contextily==1.2.0
 
 # nobinary
 aiohttp==3.8.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -79,6 +79,7 @@ rioxarray
 rio-cogeo
 Rtree
 urbanaccess
+contextily
 
 --extra-index-url="https://google-coral.github.io/py-repo/" tflite_runtime
 


### PR DESCRIPTION
`contextily` is a small Python package for adding basemaps behind `geopandas` plots. It would make plotting spatial data from DEA and DEA Coastlines easier by adding context to our data, e.g.:

https://geopandas.org/en/stable/gallery/plotting_basemap_background.html
https://contextily.readthedocs.io/en/latest/

From testing in the Sandbox I don't think it has any problematic dependencies, but we'll see how the tests run.