### PR TITLE
Add odc-geo to DEA Sandbox docker image

### DIFF
--- a/docker/requirements-odc.txt
+++ b/docker/requirements-odc.txt
@@ -7,6 +7,7 @@ odc-io
 odc-stac
 odc-stats[ows]
 odc-ui
+odc-geo
 
 # currently only available from dea packages
 --extra-index-url="https://packages.dea.ga.gov.au"


### PR DESCRIPTION
Because #225 is blocked, this is a small PR to add `odc-geo` to the DEA Sandbox. This is required to move functions to the publicly accessible `dea-tools` package so they can be used in the DEA Coastlines operationalisation project.