### PR TITLE
Add `pystac-client` and update `pyTMD` in Sandbox docker image

### DIFF
--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -81,7 +81,7 @@ rio-cogeo==3.0.1
 Rtree==0.9.7
 urbanaccess==0.2.2
 contextily==1.2.0
-pyTMD==1.0.6
+pyTMD==1.0.9
 
 # nobinary
 aiohttp==3.8.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -81,6 +81,7 @@ Rtree
 urbanaccess
 contextily
 pyTMD
+pystac-client
 
 --extra-index-url="https://google-coral.github.io/py-repo/" tflite_runtime
 


### PR DESCRIPTION
This PR adds `pystac-client` to our Sandbox docker image, as it is used in this STAC guide here: 
https://docs.dea.ga.gov.au/setup/gis/stac.html

This also updates the `pyTMD` tidal modelling package to the latest version (as required for DEA Coastlines):