### PR TITLE
Pin PyTMD to avoid deprecation warnings

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -186,7 +186,7 @@ dependencies:
   - Rtree
   - urbanaccess
   - contextily
-  - pyTMD==1.0.9
+  - pyTMD=1.0.9
 
 # jupyter things
   - autopep8

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -186,7 +186,7 @@ dependencies:
   - Rtree
   - urbanaccess
   - contextily
-  - pyTMD
+  - pyTMD==1.0.9
 
 # jupyter things
   - autopep8

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -186,7 +186,7 @@ dependencies:
   - Rtree
   - urbanaccess
   - contextily
-  - pyTMD=1.0.9
+  - pyTMD<2.0
 
 # jupyter things
   - autopep8


### PR DESCRIPTION
The latest version 2.0 of PyTMD includes a major refactor that products many deprecation warnings:
![image](https://user-images.githubusercontent.com/17680388/214478419-be3607b4-fe02-4616-a45c-6a617c1c243a.png)

Until we can update our code to use this new version, we should pin a pre-2.0 version in the Sandbox image.