### PR TITLE
upgrade dependencies and revolve issues

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ ENV LC_ALL=C.UTF-8 \
     PROJ_LIB=/env/share/proj \
     GDAL_DATA=/env/share/gdal \
     SQLALCHEMY_SILENCE_UBER_WARNING=1 \
+    USE_PYGEOS=0 \
     PATH=/env/bin:$PATH
 
 USER $nb_user

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ ENV LC_ALL=C.UTF-8 \
     GDAL_DRIVER_PATH=/env/lib/gdalplugins \
     PROJ_LIB=/env/share/proj \
     GDAL_DATA=/env/share/gdal \
+    SQLALCHEMY_SILENCE_UBER_WARNING=1 \
     PATH=/env/bin:$PATH
 
 USER $nb_user

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - libgdal
   - gdal<3.6.2
   - proj
-  - rasterio>1.3.2
+  - rasterio>=1.3.2
   - gcc_linux-64
   - gxx_linux-64
   - binutils_linux-64
@@ -66,7 +66,6 @@ dependencies:
   - imageio
   - importlib-metadata
   - importlib-resources
-  - ipycytoscape
   - iso8601
   - itsdangerous
   - Jinja2
@@ -155,7 +154,7 @@ dependencies:
   - bottleneck
 # Scientific Stack
   - gsl
-  - cgal
+  - cgal-cpp
   - boost
   - openmp
   - muparser
@@ -188,7 +187,6 @@ dependencies:
   - urbanaccess
   - contextily
   - pyTMD<2.0
-
 # jupyter things
   - autopep8
   - black
@@ -202,7 +200,7 @@ dependencies:
   - jupyterlab-geojson
   - jupyterlab-git
   - jupyterlab_iframe
-  - jupyterlab_widgets=1.1.1
+  - jupyterlab_widgets
   - jupyterlab-topbar
   - jupyterlab-system-monitor
   - jupyterhub
@@ -212,6 +210,7 @@ dependencies:
   - jupyter-server-proxy
   - jupyter-ui-poll
   - ipycanvas
+  - ipycytoscape
   - ipyevents
   - ipyfilechooser
   - ipyleaflet

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -3,10 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8.10
-  - libgdal=3.5.1
-  - gdal=3.5.1
-  - proj=9.0.1
-  - rasterio=1.3.2
+  - libgdal
+  - gdal<3.6.2
+  - proj
+  - rasterio>1.3.2
   - gcc_linux-64
   - gxx_linux-64
   - binutils_linux-64
@@ -66,6 +66,7 @@ dependencies:
   - imageio
   - importlib-metadata
   - importlib-resources
+  - ipycytoscape
   - iso8601
   - itsdangerous
   - Jinja2
@@ -118,12 +119,12 @@ dependencies:
   - scipy
   - sentry-sdk
   - setuptools-scm
-  - Shapely
+  - Shapely>=2.0
   - six
   - slicerator
   - snuggs
   - sortedcontainers
-  - SQLAlchemy
+  - SQLAlchemy<2.0
   - structlog
   - tblib
   - text-unidecode
@@ -138,7 +139,7 @@ dependencies:
   - urlpath
   - Werkzeug
   - wrapt
-  - xarray=2022.3.0
+  - xarray>=2023.1.0
   - yarl
   - zict
   - zipp

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,5 @@
 cognitojwt
+cgal
 line-profiler
 jupyterlab-logout
 jupyter-contrib-core


### PR DESCRIPTION
- upgrade versions of all dependencies
- put into bound required by `odc`
- resolve issues:
    - #242 
    - #243
    - #244 

Note: #244 was introduced by pr #239. We should have pinned lower `jupyterlab` rather than `jupyterlab_widgets`. It's resolved by new release on `jupyterlab`, hence removed the pin.