### PR TITLE
Update integration test

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,12 +28,12 @@ jobs:
 
       - name: Start docker-compose
         run: |
-          # cd ./dea-sandbox/integration-testing
-          # docker-compose up -d
+          cd ./dea-sandbox/integration-testing
+          docker-compose up -d
 
       - name: Set up Datacube
         run: |
           chmod 644 /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh
-          # cd ./dea-sandbox/integration-testing
-          # docker-compose exec -T index setup_test_datacube.sh
-          # docker-compose exec -T index datacube product list
+          cd ./dea-sandbox/integration-testing
+          docker-compose exec -T index setup_test_datacube.sh
+          docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,14 +28,12 @@ jobs:
 
       - name: Start docker-compose
         run: |
+          sudo chown -R 1000:100 ./dea-notebooks
           cd ./dea-sandbox/integration-testing
           CURRENT_UID=1000:100 docker-compose up -d
 
       - name: Set up Datacube and Test
         run: |
           cd ./dea-sandbox/integration-testing
-          docker-compose exec -T sandbox pwd
-          docker-compose exec -T sandbox ls -alt 
-          docker-compose exec -T sandbox pip install ./dea-notebooks/Tools
           docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
           docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Start docker-compose
         run: |
           pwd
-          cd /home/runner/work/dea-sandbox/integration-testing
+          cd /home/runner/work/dea-sandbox/dea-sandbox/integration-testing
           docker-compose up -d
 
       - name: Set up Datacube

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,10 +5,19 @@ on:
   pull_request:
     branches:
       - develop
+    paths:
+      - '.github/workflows/integration-test.yml'
+      - 'docker/**'
 
   push:
     branches:
       - develop
+    paths:
+      - '.github/workflows/integration-test.yml'
+      - 'docker/**'
+
+  release:
+    types: [published]
 
 jobs:
   integration-test:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,12 +28,12 @@ jobs:
 
       - name: Start docker-compose
         run: |
-          cd ./dea-sandbox/integration-testing
-          docker-compose up -d
+          # cd ./dea-sandbox/integration-testing
+          # docker-compose up -d
 
       - name: Set up Datacube
         run: |
-          chmod 644 /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh
-          cd ./dea-sandbox/integration-testing
-          docker-compose exec -T index setup_test_datacube.sh
-          docker-compose exec -T index datacube product list
+          ls -la /ome/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh
+          # cd ./dea-sandbox/integration-testing
+          # docker-compose exec -T index setup_test_datacube.sh
+          # docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Start docker-compose
         run: |
-          pwd
+          ls -la
           cd /home/runner/work/dea-sandbox/dea-sandbox/integration-testing
           docker-compose up -d
 

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -26,10 +26,10 @@ jobs:
           repository: GeoscienceAustralia/dea-notebooks
           path: dea-notebooks
 
-      - name: Set up Datacube
+      - name: Start docker-compose
         run: |
           pwd
-          cd ./integration-testing
+          cd /home/runner/work/dea-sandbox/dea-sandbox/integration-testing
           docker-compose up -d
 
       - name: Set up Datacube

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set up Datacube
         run: |
-          ls -la /ome/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh
+          ls -la /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh
           # cd ./dea-sandbox/integration-testing
           # docker-compose exec -T index setup_test_datacube.sh
           # docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -4,9 +4,11 @@ name: Integration Test
 on:
   pull_request:
     branches:
-        - develop
+      - develop
 
   push:
+    branches:
+      - develop
 
 jobs:
   integration-test:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,6 +28,13 @@ jobs:
 
       - name: Set up Datacube
         run: |
+          pwd
+          cd dea-sandbox/integration-testing
+          docker-compose up -d
+
+      - name: Set up Datacube
+        run: |
+          pwd
           cd dea-sandbox/integration-testing
           docker-compose exec -T index setup_test_datacube.sh
           docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set up Datacube
         run: |
-          ls -la /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh
+          chmod 644 /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh
           # cd ./dea-sandbox/integration-testing
           # docker-compose exec -T index setup_test_datacube.sh
           # docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Set up Datacube
         run: |
-          ls -la /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh
+          ls -la /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh
           # cd ./dea-sandbox/integration-testing
           # docker-compose exec -T index setup_test_datacube.sh
           # docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -13,22 +13,21 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    steps:
+      - name: git checkout dea-sandbox
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            path: dea-sandbox
 
-  steps:
-    - name: git checkout dea-sandbox
+      - name: git checkout dea-notebooks
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-          path: dea-sandbox
+          repository: GeoscienceAustralia/dea-notebooks
+          path: dea-notebooks
 
-    - name: git checkout dea-notebooks
-      uses: actions/checkout@v2
-      with:
-        repository: GeoscienceAustralia/dea-notebooks
-        path: dea-notebooks
-
-    - name: Set up Datacube
-      run: |
-        cd dea-sandbox/integration-testing
-        docker-compose exec -T index setup_test_datacube.sh
-        docker-compose exec -T index datacube product list
+      - name: Set up Datacube
+        run: |
+          cd dea-sandbox/integration-testing
+          docker-compose exec -T index setup_test_datacube.sh
+          docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Set up Datacube
         run: |
+          chmod 644 /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh
           cd ./dea-sandbox/integration-testing
           docker-compose exec -T index setup_test_datacube.sh
           docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -13,8 +13,6 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
-    env:
-      WORKDIR: /home/runner/work/dea-sandbox/dea-sandbox
     steps:
       - name: git checkout dea-sandbox
         uses: actions/checkout@v3
@@ -31,11 +29,12 @@ jobs:
       - name: Start docker-compose
         run: |
           cd ./dea-sandbox/integration-testing
-          CURRENT_UID=$(id -u):$(id -g) docker-compose up -d
+          CURRENT_UID=1000:100 docker-compose up -d
 
       - name: Set up Datacube and Test
         run: |
           cd ./dea-sandbox/integration-testing
+          docker-compose exec -T sandbox pwd
           docker-compose exec -T sandbox ls -alt 
           docker-compose exec -T sandbox pip install ./dea-notebooks/Tools
           docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git checkout dea-sandbox
-          uses: actions/checkout@v2
-          with:
-            fetch-depth: 0
-            path: dea-sandbox
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: dea-sandbox
 
       - name: git checkout dea-notebooks
         uses: actions/checkout@v2

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -45,6 +45,6 @@ jobs:
           docker-compose exec -T sandbox mkdir /home/jovyan/dea-notebooks
           docker-compose exec -T sandbox cp -r /dea-notebooks/.git /home/jovyan/.git
           docker-compose exec -T sandbox cp -r /dea-notebooks/Tools /home/jovyan/Tools
-          docker-compose exec -T sandbox pip install --use-feature=in-tree-build /home/jovyan/Tools
+          docker-compose exec -T sandbox pip install /home/jovyan/Tools
           docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests --ignore /dea-notebooks/Tests/Beginners_guide/07_Intro_to_numpy_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Animated_timeseries_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Contour_extraction_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Polygon_drill_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Tidal_modelling_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
           docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -29,12 +29,11 @@ jobs:
       - name: Set up Datacube
         run: |
           pwd
-          cd dea-sandbox/integration-testing
+          cd ./integration-testing
           docker-compose up -d
 
       - name: Set up Datacube
         run: |
           pwd
-          cd dea-sandbox/integration-testing
           docker-compose exec -T index setup_test_datacube.sh
           docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   integration-test:
     runs-on: ubuntu-latest
+    env:
+      WORKDIR: /home/runner/work/dea-sandbox/dea-sandbox
     steps:
       - name: git checkout dea-sandbox
         uses: actions/checkout@v2
@@ -41,10 +43,7 @@ jobs:
       - name: Test with pytest
         run: |
           cd ./dea-sandbox/integration-testing
-          docker-compose exec -T sandbox pip install testbook
-          docker-compose exec -T sandbox mkdir /home/jovyan/dea-notebooks
-          docker-compose exec -T sandbox cp -r /dea-notebooks/.git /home/jovyan/.git
-          docker-compose exec -T sandbox cp -r /dea-notebooks/Tools /home/jovyan/Tools
-          docker-compose exec -T sandbox pip install /home/jovyan/Tools
-          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests --ignore /dea-notebooks/Tests/Beginners_guide/07_Intro_to_numpy_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Animated_timeseries_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Contour_extraction_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Polygon_drill_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Tidal_modelling_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
-          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
+          docker-compose exec -T sandbox pip install testbook /dea-notebooks/Tools
+
+          docker-compose exec -T sandbox bash "-c" "cd /dea-notebooks; pytest /dea-notebooks/Tests --ignore /dea-notebooks/Tests/Beginners_guide/07_Intro_to_numpy_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Animated_timeseries_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Contour_extraction_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Polygon_drill_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Tidal_modelling_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
+          docker-compose exec -T sandbox bash "-c" "cd /dea-notebooks; pytest /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -35,5 +35,5 @@ jobs:
         run: |
           chmod 644 /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh
           cd ./dea-sandbox/integration-testing
-          docker-compose exec -T index setup_test_datacube.sh
+          docker-compose exec -T index sh /usr/local/bin/setup_test_datacube.sh
           docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -30,6 +30,7 @@ jobs:
         run: |
           ls -la
           cd ./dea-sandbox/integration-testing
+          pwd
           docker-compose up -d
 
       - name: Set up Datacube

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -17,39 +17,25 @@ jobs:
       WORKDIR: /home/runner/work/dea-sandbox/dea-sandbox
     steps:
       - name: git checkout dea-sandbox
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           path: dea-sandbox
 
       - name: git checkout dea-notebooks
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: GeoscienceAustralia/dea-notebooks
           path: dea-notebooks
+          ref: clean_test_workflow
 
       - name: Start docker-compose
         run: |
           cd ./dea-sandbox/integration-testing
-          docker-compose up -d
+          CURRENT_UID=$(id -u):$(id -g) docker-compose up -d
 
-      - name: Set up Datacube
-        run: |
-          chmod 644 /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh
-          cd ./dea-sandbox/integration-testing
-          docker-compose exec -T index sh /usr/local/bin/setup_test_datacube.sh
-          docker-compose exec -T index datacube product list
-
-      - name: Test with pytest
+      - name: Set up Datacube and Test
         run: |
           cd ./dea-sandbox/integration-testing
-          docker-compose exec -T sandbox pip install testbook
-
-          docker-compose exec -T sandbox mkdir /home/jovyan/dea-notebooks
-          docker-compose exec -T sandbox cp -r /dea-notebooks/.git /home/jovyan/.git
-          docker-compose exec -T sandbox cp -r /dea-notebooks/Tools /home/jovyan/Tools
-          docker-compose exec -T sandbox pip install /home/jovyan/Tools
-
-          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests --ignore /dea-notebooks/Tests/Beginners_guide/07_Intro_to_numpy_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Animated_timeseries_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Contour_extraction_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Polygon_drill_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Tidal_modelling_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
-
-          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
+          docker-compose exec -T sandbox pip install ./dea-notebooks/Tools
+          docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
+          docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Start docker-compose
         run: |
           ls -la
-          cd /home/runner/work/dea-sandbox/dea-sandbox/integration-testing
+          cd ./dea-sandbox/integration-testing
           docker-compose up -d
 
       - name: Set up Datacube

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -37,3 +37,14 @@ jobs:
           cd ./dea-sandbox/integration-testing
           docker-compose exec -T index sh /usr/local/bin/setup_test_datacube.sh
           docker-compose exec -T index datacube product list
+
+      - name: Test with pytest
+        run: |
+          cd ./dea-sandbox/integration-testing
+          docker-compose exec -T sandbox pip install testbook
+          docker-compose exec -T sandbox mkdir /home/jovyan/dea-notebooks
+          docker-compose exec -T sandbox cp -r /dea-notebooks/.git /home/jovyan/.git
+          docker-compose exec -T sandbox cp -r /dea-notebooks/Tools /home/jovyan/Tools
+          docker-compose exec -T sandbox pip install --use-feature=in-tree-build /home/jovyan/Tools
+          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests --ignore /dea-notebooks/Tests/Beginners_guide/07_Intro_to_numpy_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Animated_timeseries_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Contour_extraction_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Polygon_drill_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Tidal_modelling_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
+          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Start docker-compose
         run: |
           pwd
-          cd /home/runner/work/dea-sandbo/integration-testing
+          cd /home/runner/work/dea-sandbox/integration-testing
           docker-compose up -d
 
       - name: Set up Datacube

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Start docker-compose
         run: |
           pwd
-          cd /home/runner/work/dea-sandbox/dea-sandbox/integration-testing
+          cd /home/runner/work/dea-sandbo/integration-testing
           docker-compose up -d
 
       - name: Set up Datacube

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -36,6 +36,7 @@ jobs:
       - name: Set up Datacube and Test
         run: |
           cd ./dea-sandbox/integration-testing
+          docker-compose exec -T sandbox ls -alt 
           docker-compose exec -T sandbox pip install ./dea-notebooks/Tools
           docker-compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
           docker-compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -28,13 +28,11 @@ jobs:
 
       - name: Start docker-compose
         run: |
-          ls -la
           cd ./dea-sandbox/integration-testing
-          pwd
           docker-compose up -d
 
       - name: Set up Datacube
         run: |
-          pwd
+          cd ./dea-sandbox/integration-testing
           docker-compose exec -T index setup_test_datacube.sh
           docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,32 @@
+---
+name: Integration Test
+
+on:
+  pull_request:
+    branches:
+        - develop
+
+  push:
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+
+  steps:
+    - name: git checkout dea-sandbox
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: dea-sandbox
+
+    - name: git checkout dea-notebooks
+      uses: actions/checkout@v2
+      with:
+        repository: GeoscienceAustralia/dea-notebooks
+        path: dea-notebooks
+
+    - name: Set up Datacube
+      run: |
+        cd dea-sandbox/integration-testing
+        docker-compose exec -T index setup_test_datacube.sh
+        docker-compose exec -T index datacube product list

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -43,7 +43,13 @@ jobs:
       - name: Test with pytest
         run: |
           cd ./dea-sandbox/integration-testing
-          docker-compose exec -T sandbox pip install testbook /dea-notebooks/Tools
+          docker-compose exec -T sandbox pip install testbook
 
-          docker-compose exec -T sandbox bash "-c" "cd /dea-notebooks; pytest /dea-notebooks/Tests --ignore /dea-notebooks/Tests/Beginners_guide/07_Intro_to_numpy_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Animated_timeseries_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Contour_extraction_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Polygon_drill_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Tidal_modelling_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
-          docker-compose exec -T sandbox bash "-c" "cd /dea-notebooks; pytest /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
+          docker-compose exec -T sandbox mkdir /home/jovyan/dea-notebooks
+          docker-compose exec -T sandbox cp -r /dea-notebooks/.git /home/jovyan/.git
+          docker-compose exec -T sandbox cp -r /dea-notebooks/Tools /home/jovyan/Tools
+          docker-compose exec -T sandbox pip install /home/jovyan/Tools
+
+          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests --ignore /dea-notebooks/Tests/Beginners_guide/07_Intro_to_numpy_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Animated_timeseries_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Contour_extraction_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Polygon_drill_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Tidal_modelling_test.py --ignore /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"
+
+          docker-compose exec -T sandbox bash "-c" "cd /home/jovyan/dea-notebooks; pytest /dea-notebooks/Tests/Frequently_used_code/Rasterize_vectorize_test.py"

--- a/.github/workflows/sandbox-build-push.yml
+++ b/.github/workflows/sandbox-build-push.yml
@@ -78,6 +78,14 @@ jobs:
           role-to-assume: arn:aws:iam::538673716275:role/github-actions-role
           aws-region: ap-southeast-2
 
+      - name: Wait for tests to succeed
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'Integration Test'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+
       - name: Push image to ECR
         uses: whoan/docker-build-with-cache-action@master
         with:
@@ -85,3 +93,4 @@ jobs:
           registry: 538673716275.dkr.ecr.ap-southeast-2.amazonaws.com
           image_name: ${{ env.IMAGE_NAME }}
           image_tag: latest,${{ steps.tag-image.outputs.TAG }}
+          build_extra_args: '{"--build-arg": "UPDATE_VERSION=${{ steps.tag-image.outputs.TAG }}"}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN micromamba create  -y -p /env -f /conf/env.yaml && \
     micromamba env export -p /env --explicit
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
+ARG UPDATE_VERSION=1
 COPY requirements.txt /conf/
 # required to build hdmedians
 # or any --no-binary

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
         - postgres
      entrypoint: bash -c 'sleep infinity'
      volumes:
-       - /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks:/dea-notebooks
+       - ${WORKDIR}/dea-notebooks:/dea-notebooks
 
   index:
      image: opendatacube/datacube-index:latest
@@ -41,7 +41,7 @@ services:
         - DB_PORT=5432
         - AWS_DEFAULT_REGION=ap-southeast-2
      volumes:
-        - /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
+        - ${WORKDIR}/dea-notebooks/Tests/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
      depends_on:
         - postgres
      entrypoint: bash -c 'sleep infinity'

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
 
   sandbox:
      build:
-      context: ../
+      context: ../docker
      environment:
        - DB_HOSTNAME=postgres
        - DB_USERNAME=postgres

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
 
   sandbox:
      build:
-      context: /home/runner/work/dea-sandbox/dea-sandbox
+      context: ../
      environment:
        - DB_HOSTNAME=postgres
        - DB_USERNAME=postgres

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -14,7 +14,8 @@ services:
     restart: always
 
   sandbox:
-     build: /home/runner/work/dea-sandbox/dea-sandbox/Dockerfile
+     build:
+      context: /home/runner/work/dea-sandbox/dea-sandbox
      environment:
        - DB_HOSTNAME=postgres
        - DB_USERNAME=postgres

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -14,10 +14,7 @@ services:
     restart: always
 
   sandbox:
-     build:
-      context: docker
-      args:
-        - WITH_SUDO=yes
+     build: ../
      environment:
        - DB_HOSTNAME=postgres
        - DB_USERNAME=postgres

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
         - DB_PORT=5432
         - AWS_DEFAULT_REGION=ap-southeast-2
      volumes:
-        - /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
+        - /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/Tests/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
      depends_on:
         - postgres
      entrypoint: bash -c 'sleep infinity'

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   postgres:
     image: postgres:11.5-alpine
     ports:
-      - "5434:5432"
+      - "5455:5432"
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_PASSWORD=opendatacubepassword
@@ -29,7 +29,7 @@ services:
         - postgres
      entrypoint: bash -c 'sleep infinity'
      volumes:
-       - /home/runner/work/dea-notebooks:/dea-notebooks
+       - /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks:/dea-notebooks
 
   index:
      image: opendatacube/datacube-index:latest
@@ -41,7 +41,7 @@ services:
         - DB_PORT=5432
         - AWS_DEFAULT_REGION=ap-southeast-2
      volumes:
-        - /home/runner/work/dea-notebooks/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
+        - /home/runner/work/dea-sandbox/dea-sandbox/dea-notebooks/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
      depends_on:
         - postgres
      entrypoint: bash -c 'sleep infinity'

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -1,0 +1,49 @@
+version: "3.6"
+
+services:
+  postgres:
+    image: postgres:11.5-alpine
+    ports:
+      - "5434:5432"
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_PASSWORD=opendatacubepassword
+      - POSTGRES_USER=postgres
+    expose:
+      - 5432
+    restart: always
+
+  sandbox:
+     build:
+      context: docker
+      args:
+        - WITH_SUDO=yes
+     environment:
+       - DB_HOSTNAME=postgres
+       - DB_USERNAME=postgres
+       - DB_PASSWORD=opendatacubepassword
+       - DB_DATABASE=postgres
+       - AWS_DEFAULT_REGION=ap-southeast-2
+       - AWS_ACCESS_KEY_ID=fake_id
+       - AWS_SECRET_ACCESS_KEY=fake_key
+       - AWS_NO_SIGN_REQUEST=YES
+     depends_on:
+        - postgres
+     entrypoint: bash -c 'sleep infinity'
+     volumes:
+       - /home/runner/work/dea-notebooks:/dea-notebooks
+
+  index:
+     image: opendatacube/datacube-index:latest
+     environment:
+        - DB_HOSTNAME=postgres
+        - DB_USERNAME=postgres
+        - DB_PASSWORD=opendatacubepassword
+        - DB_DATABASE=postgres
+        - DB_PORT=5432
+        - AWS_DEFAULT_REGION=ap-southeast-2
+     volumes:
+        - /home/runner/work/dea-notebooks/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
+     depends_on:
+        - postgres
+     entrypoint: bash -c 'sleep infinity'

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     restart: always
 
   sandbox:
-     build: ../
+     build: /home/runner/work/dea-sandbox/dea-sandbox/Dockerfile
      environment:
        - DB_HOSTNAME=postgres
        - DB_USERNAME=postgres

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -28,20 +28,6 @@ services:
      depends_on:
         - postgres
      entrypoint: bash -c 'sleep infinity'
+     user: ${CURRENT_UID}
      volumes:
-       - ${WORKDIR}/dea-notebooks:/dea-notebooks
-
-  index:
-     image: opendatacube/datacube-index:latest
-     environment:
-        - DB_HOSTNAME=postgres
-        - DB_USERNAME=postgres
-        - DB_PASSWORD=opendatacubepassword
-        - DB_DATABASE=postgres
-        - DB_PORT=5432
-        - AWS_DEFAULT_REGION=ap-southeast-2
-     volumes:
-        - ${WORKDIR}/dea-notebooks/Tests/setup_test_datacube.sh:/usr/local/bin/setup_test_datacube.sh
-     depends_on:
-        - postgres
-     entrypoint: bash -c 'sleep infinity'
+       - ${WORKDIR}/dea-notebooks:/home/jovyan/dea-notebooks

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -30,4 +30,4 @@ services:
      entrypoint: bash -c 'sleep infinity'
      user: ${CURRENT_UID}
      volumes:
-       - ${WORKDIR}/dea-notebooks:/home/jovyan/dea-notebooks
+       - ${GITHUB_WORKSPACE}/dea-notebooks:/home/jovyan/dea-notebooks


### PR DESCRIPTION
Based on PR #235 from @pindge 
Further changes:
- reuse the test shell script in `dea-notebooks` to avoid huge chunk of copy/paste. The necessary changes sit on this pr https://github.com/GeoscienceAustralia/dea-notebooks/pull/1008. I'll need to push a new docker image to pass the test workflow in the above PR. Hence further change will be made to checkout `develop` branch of `dea-notebooks` instead `clean_test_workflow` after this pr is merged.
- mount volume instead of copying the file. I don't have a better way than `chown` to resolve the access issue between host and container.
- remove `index` image since the test script will patch the sandbox image with `odc-apps-dc-tools`
- publish the docker image iff. the integration test succeeds
- burn the cache if only the version upgrade on odc family is required

Note:
The publish process can be only tested after merging. I'll address related issues if any then. 
Coastline test failure was due to broken hellfish service