### PR TITLE
Pin scipy to >=1.10.1

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,6 +19,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest
@@ -34,6 +38,15 @@ jobs:
           repository: GeoscienceAustralia/dea-notebooks
           path: dea-notebooks
           ref: stable
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::538673716275:role/github-actions-role-readonly
+          aws-region: ap-southeast-2
+
+      - name: Copy tide modelling files with the AWS CLI
+        run: aws s3 sync s3://dea-non-public-data/tide_models/tide_models tide_models
 
       - name: Start docker-compose
         run: |

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -115,7 +115,7 @@ dependencies:
   - ruamel.yaml.clib
   - s3transfer
   - scikit-image
-  - scipy
+  - scipy>=1.10.1
   - sentry-sdk
   - setuptools-scm
   - Shapely>=2.0

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -31,3 +31,4 @@ services:
      user: ${CURRENT_UID}
      volumes:
        - ${GITHUB_WORKSPACE}/dea-notebooks:/home/jovyan/dea-notebooks
+       - ${GITHUB_WORKSPACE}/tide_models:/var/share/tide_models


### PR DESCRIPTION
A bug in Scipy 1.10.0 has broken some of our DEA Notebooks and coastal functions, reported here: https://github.com/GeoscienceAustralia/dea-notebooks/issues/1063

This PR pins to scipy versions >= 1.10.1 which fix this bug. More details: https://github.com/scipy/scipy/issues/17718