### PR TITLE
Remove `pyTMD<2.0` restriction, add `spyndex`

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -197,6 +197,7 @@ dependencies:
   - rio-stac
   - rioxarray
   - Rtree
+  - spyndex
   - urbanaccess
   - contextily
   - pyTMD

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -2,7 +2,7 @@ name: env
 channels:
   - conda-forge
 dependencies:
-  - python=3.8.10
+  - python=3.10.0
   - libgdal
   - gdal<3.6.2
   - proj

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -2,7 +2,7 @@ name: env
 channels:
   - conda-forge
 dependencies:
-  - python=3.10.0
+  - python=3.10
   - libgdal
   - gdal<3.6.2
   - proj

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -199,7 +199,7 @@ dependencies:
   - Rtree
   - urbanaccess
   - contextily
-  - pyTMD<2.0
+  - pyTMD
 # jupyter things
   - autopep8
   - black

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,10 +9,16 @@ jupyter-nbextensions-configurator
 # ODC/DEA: these are installed in builder stage
 otps
 eodatasets3
+
+# Damien - August 2023
+# These are causing trouble, and are hopefully no longer required.
+#
 # rsgislib was manually packaged as a binary wheel
 # rios required by rsgislib no PIPy publish
-https://github.com/ubarsc/rios/releases/download/rios-1.4.13/rios-1.4.13.tar.gz
-rsgislib==4.1.95
+#https://github.com/ubarsc/rios/releases/download/rios-1.4.13/rios-1.4.13.tar.gz
+#rsgislib==4.1.95
+
+
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
 s2cloudmask


### PR DESCRIPTION
We recently updated DEA Notebooks to use pyTMD >= 2.0: https://github.com/GeoscienceAustralia/dea-notebooks/pull/1077
This PR removes the previous < 2.0 requirement.

Also adds the `spyndex` spectral indices package: https://spyndex.readthedocs.io/en/latest/