### PR TITLE
Add DEA Tools and minimum pyTMD version

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -164,6 +164,7 @@ dependencies:
   - voluptuous
   - bottleneck
 # Scientific Stack
+  - dea-tools
   - gsl
   - cgal-cpp
   - boost
@@ -201,7 +202,7 @@ dependencies:
   - spyndex
   - urbanaccess
   - contextily
-  - pyTMD
+  - pyTMD>=2.0.8
 # jupyter things
   - autopep8
   - black

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -164,7 +164,6 @@ dependencies:
   - voluptuous
   - bottleneck
 # Scientific Stack
-  - dea-tools
   - gsl
   - cgal-cpp
   - boost

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -18,7 +18,8 @@ s2cloudmask
 opencv-python-headless
 opencv-contrib-python-headless
 
-datacube[performance,s3]
+jsonschema < 4.18
+datacube[performance,s3] == 1.8.15
 odc-algo
 odc-cloud[ASYNC]
 odc-dscache

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -27,6 +27,7 @@ odc-stac
 odc-stats[ows]
 odc-ui
 odc-geo
+dea-tools
 
 thredds-crawler
 hdstats==0.1.8.post1


### PR DESCRIPTION
Our coastal notebooks on the DEA Sandbox are currently broken because DEA Tools is no longer installed on the Sandbox by default. This also causes a related issue where our current image has only an out-dated version of `pyTMD`, which is required for our tide modelling aplications.

To fix this, this PR:

- Adds DEA Tools to our Docker image 
- Adds a minimum version to our `pyTMD` tide modelling package