### PR TITLE
update odc core version and remove install dea-tools from local folder

### DIFF
--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -15,9 +15,5 @@ BRANCH="${2:-master}"
     rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,docker-compose.yml,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
     cp -Rv ${WORKDIR}/. ~/
     rm -rf "${WORKDIR}"
-    # Install Tools folder if available
-    if [ -e $HOME/Tools/setup.py ]; then
-        python -m pip install -e "$HOME/Tools" || true
-    fi
     rm -rf "$HOME/.git"
 }

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.10
   - libgdal
-  - gdal
+  - gdal>=3.7.3
   - proj
   - rasterio>=1.3.2
   - gcc_linux-64

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.10
   - libgdal
-  - gdal>=3.7.3
+  - gdal
   - proj
   - rasterio>=1.3.2
   - gcc_linux-64
@@ -173,7 +173,7 @@ dependencies:
   - dask-ml
   - pathos
   - scikit-learn
-  - tensorflow=2.7
+  - tensorflow>=2.10
   - xgboost
   - zarr
   - bokeh

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -75,7 +75,7 @@ dependencies:
   - itsdangerous
   - Jinja2
   - jmespath
-  - jsonschema<4.18
+  - jsonschema>4.18
   - kiwisolver
   - lark
   - python-lmdb

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -176,7 +176,7 @@ dependencies:
   - tensorflow>=2.10
   - xgboost
   - zarr
-  - bokeh
+  - bokeh=3.2.2
   - descartes
   - matplotlib
   - seaborn

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -18,8 +18,7 @@ s2cloudmask
 opencv-python-headless
 opencv-contrib-python-headless
 
-jsonschema < 4.18
-datacube[performance,s3] == 1.8.15
+datacube[performance,s3] >= 1.8.17
 odc-algo
 odc-cloud[ASYNC]
 odc-dscache

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -19,7 +19,7 @@ opencv-python-headless
 opencv-contrib-python-headless
 
 datacube[performance,s3] >= 1.8.17
-odc-algo
+odc-algo @ git+https://github.com/opendatacube/odc-algo@b8dcfce
 odc-cloud[ASYNC]
 odc-dscache
 odc-io


### PR DESCRIPTION
- update `odc-core >= 1.8.17`
- remove pin on lower version of `jsonschema`
- remove pip install `dea-tools` from the local folder as it's built into the image now
- sync the change in `odc-stats` production docker due to bug fix, **note: can't pin `gdal>=3.7.3` as conflict with `pygeos` is unsolvable.**
- pin `tensorflow` to higher stable version
- pin `bokeh==3.2.2` due to dask dashboard issue ref: https://github.com/dask/distributed/issues/8333 https://github.com/bokeh/bokeh/issues/13521