### PR TITLE
Update `odc-geo` to resolve projection bug

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -26,7 +26,7 @@ odc-io
 odc-stac
 odc-stats[ows]
 odc-ui
-odc-geo
+odc-geo >= 0.4.2
 dea-tools
 
 thredds-crawler


### PR DESCRIPTION
The current version of `odc-geo` has a bug that affects spatial processing of certain datasets with non-standard CRS information: https://github.com/opendatacube/odc-geo/issues/120

This is fixed in [`odc-geo==0.4.2`](https://github.com/opendatacube/odc-geo/releases/tag/v0.4.2). This PR updates the Sandbox to use this image, so we can more easily analyse data on the Sandbox.