### PR TITLE
Update DEA Sandbox image (March 2024)

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -26,7 +26,7 @@ odc-io
 odc-stac
 odc-stats[ows]
 odc-ui
-odc-geo >= 0.4.2
+odc-geo
 dea-tools
 
 thredds-crawler


### PR DESCRIPTION
Update the DEA Sandbox image to get latest versions of:

- `eodatasets3`
- `odc-geo`
- `odc-stats`
- `dea-tools`