### PR TITLE
Update DEA Sandbox image

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -29,7 +29,7 @@ odc-io
 odc-stac
 odc-stats[ows]
 odc-ui
-odc-geo >= 0.4.2
+odc-geo
 dea-tools
 
 thredds-crawler

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -29,7 +29,7 @@ odc-io
 odc-stac
 odc-stats[ows]
 odc-ui
-odc-geo
+odc-geo >= 0.4.2
 dea-tools
 
 thredds-crawler


### PR DESCRIPTION
Key package updates:

- `datacube`: 1.8.18
- `odc-geo`: 0.4.3
- `dea_tools`: 0.3.2
- `eodatasets3`: 0.30.4
- `odc-stats`: 1.0.42