### PR TITLE
Fix new user role setup on ARE 

### DIFF
--- a/nci_environment/dea/scripts/datacube-ensure-user.py
+++ b/nci_environment/dea/scripts/datacube-ensure-user.py
@@ -57,10 +57,6 @@ def main(hostname, port, dbusername):
     ~/.pgpass can have <hostname>:<port>:<database>:<username>:<password>
           e.g., *:*:*:<dbusername>:<password>
     """
-
-    if "PBS_JOBID" in os.environ:
-        return
-
     dbcreds = DBCreds(
         host=hostname,
         port=str(port),


### PR DESCRIPTION
Remove exit on `PBS_JOBID` as it causes `datacube-ensure-user` script to silently fail when run on ARE, preventing new user roles from being set up correctly.