### PR TITLE
Update Sandbox image packages

### DIFF
--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -17,6 +17,8 @@ on:
 env:
   ORG: dea
   IMAGE: dea-sandbox
+  DIVE: wagoodman/dive:v0.12.0
+  DOCKER_API: 1.37
 
 jobs:
   dive:
@@ -81,11 +83,11 @@ jobs:
           sudo rm -rf ${GITHUB_WORKSPACE}/.git
 
       - name: Dive
-        uses: yuichielectric/dive-action@0.0.3
-        with:
-          image: ${{ env.ORG }}/${{ env.IMAGE}}:_build
-          config-file: ${{ github.workspace }}/dive-ci.yml
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker pull ${DIVE}
+          docker run -e CI=true -e DOCKER_API_VERSION=${DOCKER_API} --rm -v /var/run/docker.sock:/var/run/docker.sock \
+          --mount type=bind,source=${{ github.workspace }}/dive-ci.yml,target=/.dive-ci \
+          ${DIVE}  --ci-config /.dive-ci ${ORG}/${IMAGE}:_build
 
       - name: Docker image size check
         uses: wemake-services/docker-image-size-limit@master

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -109,7 +109,7 @@ dependencies:
   - pyproj
   - pyrsistent
   - pystac
-  - pystac-client>=0.8.2
+  - pystac-client>=0.8.1
   - pytest!=8.1.0
   - python-dateutil
   - python-rapidjson

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -205,6 +205,7 @@ dependencies:
   - urbanaccess
   - contextily
   - pyTMD<=2.1.0
+  - xarray-spatial
 # jupyter things
   - autopep8
   - black

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -13,6 +13,7 @@ dependencies:
   - libpq
   - git
   - wget
+  - curl
   - unzip
   - htop
   - tmux
@@ -66,7 +67,7 @@ dependencies:
   - geopandas<1.0.0
   - greenlet
   - HeapDict
-  - icu
+  - icu>=73.2
   - idna
   - imageio
   - importlib-metadata
@@ -174,14 +175,14 @@ dependencies:
   - dask-ml
   - pathos
   - scikit-learn
-  - tensorflow>=2.10
+  - tensorflow>=2.16
   - xgboost
   - zarr
   - bokeh=3.2.2
   - descartes
   - matplotlib
   - seaborn
-  - pygeos
+    # - pygeos
   - cmocean
   - gcsfs
   - geohash2

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -63,7 +63,7 @@ dependencies:
   - frozenlist
   - fsspec
   - GeoAlchemy2
-  - geopandas
+  - geopandas<1.0.0
   - greenlet
   - HeapDict
   - icu
@@ -109,7 +109,7 @@ dependencies:
   - pyproj
   - pyrsistent
   - pystac
-  - pystac-client
+  - pystac-client>=0.8.2
   - pytest!=8.1.0
   - python-dateutil
   - python-rapidjson
@@ -183,6 +183,7 @@ dependencies:
   - seaborn
   - pygeos
   - cmocean
+  - gcsfs
   - geohash2
   - geojson
   - geopy

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -21,7 +21,7 @@ s2cloudmask
 opencv-python-headless
 opencv-contrib-python-headless
 
-datacube[performance,s3] >= 1.8.17
+datacube[performance,s3] >= 1.8.19
 odc-algo @ git+https://github.com/opendatacube/odc-algo@b8dcfce
 odc-cloud[ASYNC]
 odc-dscache


### PR DESCRIPTION
This PR makes the following changes to our DEA Sandbox image:

- Uses latest versions of `datacube` and `odc-geo` to fix ESRI/GDAL nodata bug
- Adds `gcsfs` and `xarray-spatial` (providing access to ERA5 climate data stored in Google Cloud, and advanced spatial processing methods for DEM data)
- Pins `geopandas` to less than 1.0.0 for compatibility
- Upgrades `tensorflow`
- Adds `curl` (missing from recent `gdal` updates?)
