### PR TITLE
Add minimum package versions for ESRI/GDAL nodata fix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,8 +45,10 @@ jobs:
           role-to-assume: arn:aws:iam::538673716275:role/github-actions-role-readonly
           aws-region: ap-southeast-2
 
-      - name: Copy tide modelling files with the AWS CLI
-        run: aws s3 sync s3://dea-non-public-data/tide_models/tide_models tide_models
+    - name: Copy tide modelling files with the AWS CLI
+      run: |
+        aws s3 sync s3://dea-non-public-data/tide_models/tide_models/fes2014 tide_models/fes2014
+        aws s3 sync s3://dea-non-public-data/tide_models/tide_models/hamtide tide_models/hamtide
 
       - name: Start docker-compose
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,10 +45,10 @@ jobs:
           role-to-assume: arn:aws:iam::538673716275:role/github-actions-role-readonly
           aws-region: ap-southeast-2
 
-    - name: Copy tide modelling files with the AWS CLI
-      run: |
-        aws s3 sync s3://dea-non-public-data/tide_models/tide_models/fes2014 tide_models/fes2014
-        aws s3 sync s3://dea-non-public-data/tide_models/tide_models/hamtide tide_models/hamtide
+      - name: Copy tide modelling files with the AWS CLI
+        run: |
+          aws s3 sync s3://dea-non-public-data/tide_models/tide_models/fes2014 tide_models/fes2014
+          aws s3 sync s3://dea-non-public-data/tide_models/tide_models/hamtide tide_models/hamtide
 
       - name: Start docker-compose
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,15 +48,6 @@ RUN echo "Enable server extensions" \
    && jupyter server extension list \
    && echo "...done"
 
-RUN echo "Install AWS CLI v2" \
-   && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" \
-   && unzip /tmp/awscliv2.zip -d /tmp \
-   && /tmp/aws/install -i /env/bin/aws-cli -b /env/bin \
-   && aws --version \
-   && rm -f /tmp/awscliv2.zip \
-   && rm -fr /tmp/aws \
-   && echo "...done"
-
 COPY assets/sync_repo assets/jupyterhub-singleuser /usr/local/bin/
 COPY assets/overrides.json /env/share/jupyter/lab/settings/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,8 @@ RUN echo "Enable server extensions" \
 COPY assets/sync_repo assets/jupyterhub-singleuser /usr/local/bin/
 COPY assets/overrides.json /env/share/jupyter/lab/settings/
 
+RUN pip list --format=freeze 
+
 WORKDIR "/home/$nb_user"
 ENTRYPOINT ["/env/bin/tini", "--"]
 CMD ["jupyter", "lab", \

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -205,7 +205,7 @@ dependencies:
   - spyndex
   - urbanaccess
   - contextily
-  - pyTMD<=2.1.0
+  - pyTMD
   - xarray-spatial
 # jupyter things
   - autopep8

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -21,6 +21,7 @@ dependencies:
   - rio-cogeo
   - access
   - aiobotocore
+  - awscliv2
   - boto3
   - s5cmd
   - affine

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -12,7 +12,7 @@ jupyterlab-logout==0.5.0
 
 # ODC/DEA: these are installed in builder stage
 otps
-eodatasets3 => 0.30.6  # required for ESRI/GDAL nodata fix
+eodatasets3 >= 0.30.6  # min version required for ESRI/GDAL nodata fix
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
@@ -21,7 +21,7 @@ s2cloudmask
 opencv-python-headless
 opencv-contrib-python-headless
 
-datacube[performance,s3] >= 1.8.19
+datacube[performance,s3] >= 1.8.19  # min version required for ESRI/GDAL nodata fix
 odc-algo @ git+https://github.com/opendatacube/odc-algo@b8dcfce
 odc-cloud[ASYNC]
 odc-dscache
@@ -29,7 +29,7 @@ odc-io
 odc-stac
 odc-stats[ows]
 odc-ui
-odc-geo
+odc-geo >= 0.4.8  # min version required for ESRI/GDAL nodata fix
 dea-tools
 
 thredds-crawler

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -12,7 +12,7 @@ jupyterlab-logout==0.5.0
 
 # ODC/DEA: these are installed in builder stage
 otps
-eodatasets3
+eodatasets3 => 0.30.6  # required for ESRI/GDAL nodata fix
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask


### PR DESCRIPTION
This PR pins minimum versions of `odc-geo` and `eodatasets` to ensure we have completely resolved the ESRI/GDAL nodata issue. Key changes include:

```
eodatasets3 >= 0.30.6  # min version required for ESRI/GDAL nodata fix
datacube[performance,s3] >= 1.8.19  # min version required for ESRI/GDAL nodata fix
odc-geo >= 0.4.8  # min version required for ESRI/GDAL nodata fix
```