### PR TITLE
Upgrade `unstable` Sandbox servers with more recent package versions

### DIFF
--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -90,7 +90,7 @@ jobs:
           ${DIVE}  --ci-config /.dive-ci ${ORG}/${IMAGE}:_build
 
       - name: Docker image size check
-        uses: wemake-services/docker-image-size-limit@master
+        uses: wemake-services/docker-image-size-limit@2.0.0
         with:
           image: ${{ env.ORG }}/${{ env.IMAGE}}:_build
           size: "8 GiB"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,7 +40,7 @@ jobs:
           path: dea-notebooks
           ref: stable
 
-      - name: provision DB connection
+      - name: Provision database connection used in DEA Notebooks integration tests
         uses: GeoscienceAustralia/dea-notebooks/.github/actions/test_setup@develop
         with:
           pull_image_optional: "false"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -85,5 +85,4 @@ jobs:
       - name: Set up Datacube and Test
         run: |
           cd ./dea-sandbox/integration-testing
-          docker compose exec -T sandbox ./dea-notebooks/Tests/setup_test_datacube.sh
           docker compose exec -T sandbox ./dea-notebooks/Tests/test_notebooks.sh

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,16 +40,10 @@ jobs:
           path: dea-notebooks
           ref: stable
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: provision DB connection:
+        uses: GeoscienceAustralia/dea-notebooks/.github/actions/test_setup/action.yml@share_git_actions
         with:
-          role-to-assume: arn:aws:iam::538673716275:role/github-actions-role-readonly
-          aws-region: ap-southeast-2
-
-      - name: Copy tide modelling files with the AWS CLI
-        run: |
-          aws s3 sync s3://dea-non-public-data/tide_models/tide_models/fes2014 tide_models/fes2014
-          aws s3 sync s3://dea-non-public-data/tide_models/tide_models/hamtide tide_models/hamtide
+          pull_image_optional: false
 
       - name: Start docker compose
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,10 +40,10 @@ jobs:
           path: dea-notebooks
           ref: stable
 
-      - name: provision DB connection:
-        uses: GeoscienceAustralia/dea-notebooks/.github/actions/test_setup/action.yml@share_git_actions
+      - name: provision DB connection
+        uses: GeoscienceAustralia/dea-notebooks/.github/actions/test_setup@share_git_actions
         with:
-          pull_image_optional: false
+          pull_image_optional: "false"
 
       - name: Start docker compose
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,7 +41,7 @@ jobs:
           ref: stable
 
       - name: provision DB connection
-        uses: GeoscienceAustralia/dea-notebooks/.github/actions/test_setup@share_git_actions
+        uses: GeoscienceAustralia/dea-notebooks/.github/actions/test_setup@develop
         with:
           pull_image_optional: "false"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:git-df79b72-jammy as sandbox-conda
+FROM mambaorg/micromamba:git-a19699f-cuda12.6.3-ubuntu24.04 AS sandbox-conda
 
 USER root
 COPY env.yaml /conf/
@@ -11,19 +11,24 @@ ARG UPDATE_VERSION=1
 COPY requirements.txt /conf/
 # required to build hdmedians
 # or any --no-binary
-ENV CC=/env/bin/x86_64-conda_cos6-linux-gnu-gcc \
-    CXX=/env/bin/x86_64-conda_cos6-linux-gnu-g++ \
-    LDSHARED="/env/bin/x86_64-conda_cos6-linux-gnu-gcc -pthread -shared -B /env/compiler_compat -L/env/lib -Wl,-rpath=/env/lib -Wl,--no-as-needed"
+ENV CC=/env/bin/x86_64-conda-linux-gnu-gcc \
+    CXX=/env/bin/x86_64-conda-linux-gnu-g++ \
+    LDSHARED="/env/bin/x86_64-conda-linux-gnu-gcc -pthread -shared -B /env/compiler_compat -L/env/lib -Wl,-rpath=/env/lib -Wl,--no-as-needed"
 RUN micromamba run -p /env pip install --no-cache-dir \
     --no-build-isolation -r /conf/requirements.txt
 
-FROM ubuntu:jammy-20240212
+FROM ubuntu:noble-20250127
 
 ARG nb_user=jovyan
 ARG nb_uid=1000
 ARG nb_gid=100
 
-RUN useradd -l -m -s /bin/bash -N -g $nb_gid -u $nb_uid $nb_user
+RUN if id -u $nb_uid >/dev/null 2>&1; then \
+        existing_user=$(getent passwd $nb_uid | cut -d: -f1); \
+        usermod -l $nb_user -d /home/$nb_user -m $existing_user; \
+    else \
+        useradd -m -s /bin/bash -N -g $nb_gid -u $nb_uid $nb_user; \
+    fi
 
 COPY --chown=$nb_uid:$nb_gid --from=sandbox-conda /env /env
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,11 +23,13 @@ ARG nb_user=jovyan
 ARG nb_uid=1000
 ARG nb_gid=100
 
-RUN if id -u $nb_uid >/dev/null 2>&1; then \
-        existing_user=$(getent passwd $nb_uid | cut -d: -f1); \
-        usermod -l $nb_user -d /home/$nb_user -m $existing_user; \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN if id -u "$nb_uid" >/dev/null 2>&1; then \
+        existing_user=$(getent passwd "$nb_uid" | cut -d: -f1); \
+        usermod -l "$nb_user" -d "/home/$nb_user" -m "$existing_user"; \
     else \
-        useradd -m -s /bin/bash -N -g $nb_gid -u $nb_uid $nb_user; \
+        useradd --no-log-init -m -s /bin/bash -N -g "$nb_gid" -u "$nb_uid" "$nb_user"; \
     fi
 
 COPY --chown=$nb_uid:$nb_gid --from=sandbox-conda /env /env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:git-a19699f-cuda12.6.3-ubuntu24.04 AS sandbox-conda
+FROM mambaorg/micromamba:git-df79b72-jammy AS sandbox-conda
 
 USER root
 COPY env.yaml /conf/
@@ -11,26 +11,19 @@ ARG UPDATE_VERSION=1
 COPY requirements.txt /conf/
 # required to build hdmedians
 # or any --no-binary
-ENV CC=/env/bin/x86_64-conda-linux-gnu-gcc \
-    CXX=/env/bin/x86_64-conda-linux-gnu-g++ \
-    LDSHARED="/env/bin/x86_64-conda-linux-gnu-gcc -pthread -shared -B /env/compiler_compat -L/env/lib -Wl,-rpath=/env/lib -Wl,--no-as-needed"
+ENV CC=/env/bin/x86_64-conda_cos6-linux-gnu-gcc \
+    CXX=/env/bin/x86_64-conda_cos6-linux-gnu-g++ \
+    LDSHARED="/env/bin/x86_64-conda_cos6-linux-gnu-gcc -pthread -shared -B /env/compiler_compat -L/env/lib -Wl,-rpath=/env/lib -Wl,--no-as-needed"
 RUN micromamba run -p /env pip install --no-cache-dir \
     --no-build-isolation -r /conf/requirements.txt
 
-FROM ubuntu:noble-20250127
+FROM ubuntu:jammy-20240212
 
 ARG nb_user=jovyan
 ARG nb_uid=1000
 ARG nb_gid=100
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN if id -u "$nb_uid" >/dev/null 2>&1; then \
-        existing_user=$(getent passwd "$nb_uid" | cut -d: -f1); \
-        usermod -l "$nb_user" -d "/home/$nb_user" -m "$existing_user"; \
-    else \
-        useradd --no-log-init -m -s /bin/bash -N -g "$nb_gid" -u "$nb_uid" "$nb_user"; \
-    fi
+RUN useradd -l -m -s /bin/bash -N -g $nb_gid -u $nb_uid $nb_user
 
 COPY --chown=$nb_uid:$nb_gid --from=sandbox-conda /env /env
 

--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -12,7 +12,7 @@ BRANCH="${2:-master}"
     until $(git clone --depth 1 --branch "$BRANCH" "$REPO" "$WORKDIR") ||  [ $NEXT_WAIT_TIME -eq 4 ]; do
       sleep $(( NEXT_WAIT_TIME++ ))
     done
-    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,pyproject.toml,docker-compose.yml,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
+    rm -rf "${WORKDIR}"/{.github,.githooks,.gitignore,.pre-commit-config.yaml,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,pyproject.toml,docker-compose.yml,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
     cp -Rv ${WORKDIR}/. ~/
     rm -rf "${WORKDIR}"
     rm -rf "$HOME/.git"

--- a/docker/assets/sync_repo
+++ b/docker/assets/sync_repo
@@ -12,7 +12,7 @@ BRANCH="${2:-master}"
     until $(git clone --depth 1 --branch "$BRANCH" "$REPO" "$WORKDIR") ||  [ $NEXT_WAIT_TIME -eq 4 ]; do
       sleep $(( NEXT_WAIT_TIME++ ))
     done
-    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,docker-compose.yml,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
+    rm -rf "${WORKDIR}"/{.github,.gitignore,LICENSE,README.md,README.rst,CITATION.cff,USAGE.rst,pyproject.toml,docker-compose.yml,DEAfrica_notebooks_template.ipynb,DEA_notebooks_template.ipynb,Scientific_workflows,Tests} || true
     cp -Rv ${WORKDIR}/. ~/
     rm -rf "${WORKDIR}"
     rm -rf "$HOME/.git"

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -18,6 +18,7 @@ dependencies:
   - htop
   - tmux
   - vim
+  - make
   - rio-cogeo
   - access
   - aiobotocore

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -2,7 +2,7 @@ name: env
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.10
   - libgdal
   - gdal
   - proj
@@ -54,7 +54,7 @@ dependencies:
   - datadog
   - deepdiff
   - defusedxml
-  - distributed
+  - distributed>=2025.4
   - docutils
   - ephem
   - fiona
@@ -92,7 +92,7 @@ dependencies:
   - netCDF4
   - networkx
   - nodejs
-  - numpy>=2.0
+  - numpy<2.0
   - ordered-set
   - packaging
   - pandas
@@ -126,7 +126,7 @@ dependencies:
   - ruamel.yaml.clib
   - s3transfer
   - scikit-image
-  - scipy>=1.10.1
+  - scipy<1.15
   - sentry-sdk
   - setuptools-scm
   - Shapely>=2.0
@@ -237,7 +237,7 @@ dependencies:
   - isort
   - nbdime
   - nbgitpuller
-  - notebook<7.0 # Compatible with nbconvert
+  - notebook
   - mypy
   - prompt-toolkit # because of line_profiler/ipython
   - nbconvert # because of jupyter_contrib_nbextensions
@@ -249,7 +249,7 @@ dependencies:
   - folium
   - ipympl
   - graphviz
-  - plotly
+  - plotly<6.1 # labextension
   - pydotplus
   - dask-labextension
   - datashader

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -193,6 +193,7 @@ dependencies:
   - geojson
   - geopy
   - h5py
+  - lightgbm
   - mapclassify
   - OWSLib
   - pandana
@@ -206,6 +207,7 @@ dependencies:
   - rsgislib
   - Rtree
   - spyndex
+  - shap
   - urbanaccess
   - contextily
   - xarray-spatial

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -2,7 +2,7 @@ name: env
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.12
   - libgdal
   - gdal
   - proj
@@ -54,7 +54,7 @@ dependencies:
   - datadog
   - deepdiff
   - defusedxml
-  - distributed>=2023.11
+  - distributed
   - docutils
   - ephem
   - fiona
@@ -64,7 +64,7 @@ dependencies:
   - frozenlist
   - fsspec
   - GeoAlchemy2
-  - geopandas<1.0.0
+  - geopandas
   - greenlet
   - HeapDict
   - icu>=73.2
@@ -92,11 +92,7 @@ dependencies:
   - netCDF4
   - networkx
   - nodejs
-  - numpy<2.0
-  # required by spark
-  - openjdk
-  - apache-sedona
-  - pyspark
+  - numpy>=2.0
   - ordered-set
   - packaging
   - pandas
@@ -138,12 +134,13 @@ dependencies:
   - slicerator
   - snuggs
   - sortedcontainers
-  - SQLAlchemy<2.0
+  - SQLAlchemy
   - statsmodels
   - structlog
   - tblib
   - text-unidecode
   - tifffile
+  - timezonefinder
   - tini
   - tomli
   - toolz
@@ -208,7 +205,7 @@ dependencies:
   - spyndex
   - urbanaccess
   - contextily
-  - pyTMD=2.1.6
+  - pyTMD=2.2.2
   - xarray-spatial
 # jupyter things
   - autopep8

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -186,7 +186,7 @@ dependencies:
   - seaborn
     # - pygeos
   - cmocean
-  - gcsfs
+  - gcsfs>=2025.5.0
   - geohash2
   - geojson
   - geopy

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -205,7 +205,6 @@ dependencies:
   - spyndex
   - urbanaccess
   - contextily
-  - pyTMD=2.2.2
   - xarray-spatial
 # jupyter things
   - autopep8

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -149,6 +149,7 @@ dependencies:
   - typing_extensions
   - urllib3
   - urlpath
+  - uv
   - Werkzeug
   - wrapt
   - xarray>=2023.1.0

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -186,6 +186,7 @@ dependencies:
   - seaborn
     # - pygeos
   - cmocean
+  - flox
   - gcsfs>=2025.5.0
   - geohash2
   - geojson

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,33 +9,35 @@ jupyterlab-code-snippets
 jupyterlab-topbar-text
 jupyterlab-logout
 jupyterlab-theme-toggler
-numexpr @ git+https://github.com/pydata/numexpr@a99412e
 
 # ODC/DEA: these are installed in builder stage
-# eodatasets3 >= 0.30.6  # min version required for ESRI/GDAL nodata fix
-eo-tides
+eo-tides>=0.7.5
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
-# s2cloudmask
-# need to be installed after to override libs with non-gl ones
+s2cloudmask
+
 opencv-python-headless
 opencv-contrib-python-headless
+datacube-ows>=1.9
+datacube[performance,s3]>=1.9.5
+eodatasets3>1.9
+numexpr>=2.11
+odc-algo>=1.0.1
+odc-apps-cloud>=0.2.2
+odc-apps-dc-tools>=0.2.12
+odc-dscache>=1.9
+odc-geo>=0.5.0rc1
+odc-stac>=0.4.0
 
-datacube[performance,s3] >= 1.8.19  # min version required for ESRI/GDAL nodata fix
-odc-algo @ git+https://github.com/opendatacube/odc-algo@b8dcfce
 odc-cloud[ASYNC]>=0.2.5
-odc-io
-odc-dscache>=0.2.3
-odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
-# odc-stats[ows]
+odc-stats[ows]>=1.9
 odc-ui
-odc-geo >= 0.4.8  # min version required for ESRI/GDAL nodata fix
-# dea-tools >= 0.3.5
+dea-tools>=0.3.5
 
-thredds-crawler
 --extra-index-url="https://packages.dea.ga.gov.au"
-# hdstats==0.1.8.post1
+thredds-crawler
+hdstats==0.1.8.post1
 # hdmedians
 # fractional_cover>=1.3.10
 # --find-links="https://packages.dea.ga.gov.au/fc"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -33,7 +33,7 @@ odc-stac>=0.4.0
 odc-cloud[ASYNC]>=0.2.5
 odc-stats[ows]>=1.9
 odc-ui
-dea-tools>=0.4.0
+dea-tools>=0.4.1
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,34 +9,34 @@ jupyterlab-code-snippets
 jupyterlab-topbar-text
 jupyterlab-logout
 jupyterlab-theme-toggler
+jupyter_tensorboard
 numexpr @ git+https://github.com/pydata/numexpr@a99412e
 
 # ODC/DEA: these are installed in builder stage
-otps
-eodatasets3 >= 0.30.6  # min version required for ESRI/GDAL nodata fix
+# eodatasets3 >= 0.30.6  # min version required for ESRI/GDAL nodata fix
+eo-tides
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
-s2cloudmask
+# s2cloudmask
 # need to be installed after to override libs with non-gl ones
 opencv-python-headless
 opencv-contrib-python-headless
 
 datacube[performance,s3] >= 1.8.19  # min version required for ESRI/GDAL nodata fix
 odc-algo @ git+https://github.com/opendatacube/odc-algo@b8dcfce
-odc-cloud[ASYNC]
-odc-dscache
+odc-cloud[ASYNC]>=0.2.5
 odc-io
-odc-stac
-odc-stats[ows]
+odc-dscache>=0.2.3
+odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
+# odc-stats[ows]
 odc-ui
 odc-geo >= 0.4.8  # min version required for ESRI/GDAL nodata fix
-dea-tools >= 0.3.5
+# dea-tools >= 0.3.5
 
 thredds-crawler
-hdstats==0.1.8.post1
-hdmedians
-datacube-stats
-fractional_cover>=1.3.10
 --extra-index-url="https://packages.dea.ga.gov.au"
---find-links="https://packages.dea.ga.gov.au/fc"
+# hdstats==0.1.8.post1
+# hdmedians
+# fractional_cover>=1.3.10
+# --find-links="https://packages.dea.ga.gov.au/fc"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -9,7 +9,6 @@ jupyterlab-code-snippets
 jupyterlab-topbar-text
 jupyterlab-logout
 jupyterlab-theme-toggler
-jupyter_tensorboard
 numexpr @ git+https://github.com/pydata/numexpr@a99412e
 
 # ODC/DEA: these are installed in builder stage

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab-logout
 jupyterlab-theme-toggler
 
 # ODC/DEA: these are installed in builder stage
-eo-tides>=0.7.5
+eo-tides>=0.8.0
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
@@ -33,7 +33,7 @@ odc-stac>=0.4.0
 odc-cloud[ASYNC]>=0.2.5
 odc-stats[ows]>=1.9
 odc-ui
-dea-tools>=0.3.5
+dea-tools>=0.4.0
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler

--- a/integration-testing/docker-compose.yaml
+++ b/integration-testing/docker-compose.yaml
@@ -1,32 +1,16 @@
 version: "3.6"
 
 services:
-  postgres:
-    image: postgres:11.5-alpine
-    ports:
-      - "5455:5432"
-    environment:
-      - POSTGRES_DB=postgres
-      - POSTGRES_PASSWORD=opendatacubepassword
-      - POSTGRES_USER=postgres
-    expose:
-      - 5432
-    restart: always
-
   sandbox:
      build:
       context: ../docker
      environment:
-       - DB_HOSTNAME=postgres
-       - DB_USERNAME=postgres
-       - DB_PASSWORD=opendatacubepassword
-       - DB_DATABASE=postgres
-       - AWS_DEFAULT_REGION=ap-southeast-2
-       - AWS_ACCESS_KEY_ID=fake_id
-       - AWS_SECRET_ACCESS_KEY=fake_key
-       - AWS_NO_SIGN_REQUEST=YES
-     depends_on:
-        - postgres
+       - DATACUBE_DB_URL=${DATACUBE_DB_URL}
+       - AWS_DEFAULT_REGION=${AWS_REGION}
+       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
+     network_mode: host
      entrypoint: bash -c 'sleep infinity'
      user: ${CURRENT_UID}
      volumes:


### PR DESCRIPTION
Edit from Robbi: This PR is intended to update and modernise the "unstable" DEA Sandbox servers, as approved in CCB request 20250708.3.

Most significant changes include:
- Updating the image integration test workflow to re-use database provisioning workflow from DEA Notebooks
- Add additional packages required for product development (e.g. `make`, `flox`, `eo-tides`, `uv`, `lightgbm`, `shap`)
- Remove numerous no longer needed packages (e.g. `hdmedians`, `otps`, `pyTMD`) and maximum pins
- Pin other important `datacube` packages to enable Datacube 1.9 and greater

A full list of new and updated packages can be viewed in the comments below: https://github.com/GeoscienceAustralia/dea-sandbox/pull/293#issuecomment-2995363075