### PR TITLE
Add workflow dispatch to Sandbox image build action

### DIFF
--- a/.github/workflows/sandbox-build-push.yml
+++ b/.github/workflows/sandbox-build-push.yml
@@ -8,6 +8,7 @@ on:
       - completed
   release:
     types: [published]
+  workflow_dispatch:
     
 env:
   IMAGE_NAME: geoscienceaustralia/sandbox


### PR DESCRIPTION
This will allow users to manually trigger a Sandbox image build and push to ECR on demand.