### PR TITLE
Update DEA Tools to re-trigger docker image build

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -33,7 +33,7 @@ odc-stac>=0.4.0
 odc-cloud[ASYNC]>=0.2.5
 odc-stats[ows]>=1.9
 odc-ui
-dea-tools>=0.4.1
+dea-tools>=0.4.2
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab-logout
 jupyterlab-theme-toggler
 
 # ODC/DEA: these are installed in builder stage
-eo-tides>=0.8.0
+eo-tides>=0.8.2
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask


### PR DESCRIPTION
This PR aims to re-trigger the "latest" Docker image build after changes made in #294.

As in #292, the test failures are expected, and are things we will fix externally (e.g. in DEA Notebooks) once the image is available in the unstable Sandbox servers.