### PR TITLE
Pin numpy<2.0 in requirements.txt to prevent overwriting conda install

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -38,6 +38,6 @@ dea-tools>=0.4.2
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler
 hdstats==0.1.8.post1
-# hdmedians
+numpy<2.0
 # fractional_cover>=1.3.10
 # --find-links="https://packages.dea.ga.gov.au/fc"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -33,7 +33,7 @@ odc-stac>=0.4.0
 odc-cloud[ASYNC]>=0.2.5
 odc-stats[ows]>=1.9
 odc-ui
-dea-tools>=0.4.2
+dea-tools>=0.4.3
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -38,6 +38,9 @@ dea-tools>=0.4.2
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler
 hdstats==0.1.8.post1
+
+# Temporarily required to prevent hdstats upgrading numpy and overruling env.yaml
 numpy<2.0
+
 # fractional_cover>=1.3.10
 # --find-links="https://packages.dea.ga.gov.au/fc"


### PR DESCRIPTION
Pin Numpy to ensure that the `hdstats` pip install doesn't overwrite the version pinned in the Conda install.

Upgrade DEA Tools to fix Dask data loading bug.

Test failures here are expected, and will be fixed on DEA Notebooks side.