### PR TITLE
Add geomad package, remove < numpy 2.0 pin

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -93,7 +93,7 @@ dependencies:
   - netCDF4
   - networkx
   - nodejs
-  - numpy<2.0
+  - numpy
   - ordered-set
   - packaging
   - pandas

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab-logout
 jupyterlab-theme-toggler
 
 # ODC/DEA: these are installed in builder stage
-eo-tides>=0.8.2
+eo-tides>=0.8.3
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
@@ -22,8 +22,9 @@ opencv-contrib-python-headless
 datacube-ows>=1.9
 datacube[performance,s3]>=1.9.5
 eodatasets3>1.9
+geomad>=1.0.0
 numexpr>=2.11
-odc-algo>=1.0.1
+odc-algo>=1.1.1
 odc-apps-cloud>=0.2.2
 odc-apps-dc-tools>=0.2.12
 odc-dscache>=1.9
@@ -38,9 +39,6 @@ dea-tools>=0.4.3
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler
 hdstats==0.1.8.post1
-
-# Temporarily required to prevent hdstats upgrading numpy and overruling env.yaml
-numpy<2.0
 
 # fractional_cover>=1.3.10
 # --find-links="https://packages.dea.ga.gov.au/fc"


### PR DESCRIPTION
This PR makes some minor updates to the `unstable` Sandbox image to remove the temporary `numpy < 2.0` pin now that the new `geomad` package is available.

This update also include some recent version updates and bug fixes that have been made to DEA packages since we updated `unstable`.