### PR TITLE
Bump python to 3.12

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -2,7 +2,7 @@ name: env
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.12
   - libgdal
   - gdal
   - proj

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -37,6 +37,7 @@ odc-ui
 dea-tools>=0.4.3
 
 --extra-index-url="https://packages.dea.ga.gov.au"
+tflite-runtime
 thredds-crawler
 
 # fractional_cover>=1.3.10

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -38,7 +38,6 @@ dea-tools>=0.4.3
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler
-hdstats==0.1.8.post1
 
 # fractional_cover>=1.3.10
 # --find-links="https://packages.dea.ga.gov.au/fc"


### PR DESCRIPTION
There have been an increasing number of python 3.10 compatibility issues, so bump the environment to 3.12