### PR TITLE
Update to latest version of ODC

### DIFF
--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -93,4 +93,4 @@ jobs:
         uses: wemake-services/docker-image-size-limit@2.0.0
         with:
           image: ${{ env.ORG }}/${{ env.IMAGE}}:_build
-          size: "9 GiB"
+          size: "8 GiB"

--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -93,4 +93,4 @@ jobs:
         uses: wemake-services/docker-image-size-limit@2.0.0
         with:
           image: ${{ env.ORG }}/${{ env.IMAGE}}:_build
-          size: "8 GiB"
+          size: "9 GiB"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab-logout
 jupyterlab-theme-toggler
 
 # ODC/DEA: these are installed in builder stage
-eo-tides>=0.10.0
+eo-tides>=0.8.3
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
@@ -34,7 +34,7 @@ odc-stac>=0.4.0
 odc-cloud[ASYNC]>=0.2.5
 odc-stats[ows]>=1.9
 odc-ui
-dea-tools>=0.4.7
+dea-tools>=0.4.3
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ jupyterlab-logout
 jupyterlab-theme-toggler
 
 # ODC/DEA: these are installed in builder stage
-eo-tides>=0.8.3
+eo-tides>=0.10.0
 
 # Dale's s2cloudmask
 #  https://github.com/daleroberts/s2cloudmask
@@ -20,7 +20,7 @@ s2cloudmask
 opencv-python-headless
 opencv-contrib-python-headless
 datacube-ows>=1.9
-datacube[performance,s3]>=1.9.5
+datacube[performance,s3]>=1.9.10
 eodatasets3>1.9
 geomad>=1.0.0
 numexpr>=2.11
@@ -34,7 +34,7 @@ odc-stac>=0.4.0
 odc-cloud[ASYNC]>=0.2.5
 odc-stats[ows]>=1.9
 odc-ui
-dea-tools>=0.4.3
+dea-tools>=0.4.7
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler


### PR DESCRIPTION
This PR aims to update the DEA Sandbox `latest` image to include the latest Datacube version 1.9.10, which fixes some important bugs that are currently impacting DEA Notebooks code: https://github.com/opendatacube/datacube-core/releases/tag/1.9.10
