### PR TITLE
Remove workflow dispatch from Sandbox image build action

### DIFF
--- a/.github/workflows/sandbox-build-push.yml
+++ b/.github/workflows/sandbox-build-push.yml
@@ -8,7 +8,6 @@ on:
       - completed
   release:
     types: [published]
-  workflow_dispatch:
     
 env:
   IMAGE_NAME: geoscienceaustralia/sandbox


### PR DESCRIPTION
This change will restrict publishing ECR images to only approved PRs on 'develop' branch and published releases by GA.