### PR TITLE
Use Github Environments to control Sandbox Image publication

### DIFF
--- a/.github/workflows/sandbox-build-push.yml
+++ b/.github/workflows/sandbox-build-push.yml
@@ -21,6 +21,7 @@ jobs:
   set_dev_tags:
     if: github.ref == 'refs/heads/develop'
       && github.event.workflow_run.conclusion == 'success'
+    environment: dev
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -37,6 +38,7 @@ jobs:
   set_release_tags:
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
+    environment: prod
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
This change configures the dependent tagging steps to apply environment specific configuration.