### PR TITLE
Fix/cleanup jupyter lab staging cache and GH runner storage prior to image build

### DIFF
--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -35,6 +35,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+
       - name: Build image
         run: |
           docker build -t ${ORG}/${IMAGE}:_build ./docker/

--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -39,19 +39,10 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
-      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
-      - name: Build image and cache layers using buildx (deafaults not to push)
-        uses: docker/build-push-action@v6
-        with:
-          context: ./docker
-          file: docker/Dockerfile
-          tags: ${{ env.ORG }}/${{ env.IMAGE }}:_build
-          load: true  # makes the built image available to 'docker' for later steps
-          cache-from: type=gha,scope=${{ env.IMAGE }}
-          cache-to: type=gha,scope=${{ env.IMAGE }},mode=max
+      - name: Build image
+        run: |
+          docker build -t ${ORG}/${IMAGE}:_build ./docker/
 
       - name: Free disk space
         run: |

--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -39,23 +39,19 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Restore BuildKit cache (local dir)
-        uses: actions/cache@v4
+      - name: Build image and cache layers using buildx (deafaults not to push)
+        uses: docker/build-push-action@v6
         with:
-          path: /tmp/buildkit-cache
-          key: buildkit-${{ runner.os }}-${{ hashFiles('docker/Dockerfile', 'docker/**') }}
-          restore-keys: |
-            buildkit-${{ runner.os }}-
-
-      - name: Build image and cache layers locally
-        env:
-          DOCKER_BUILDKIT: '1'
-        run: |
-          docker build \
-            --cache-from type=local,src=/tmp/buildkit-cache \
-            --cache-to   type=local,dest=/tmp/buildkit-cache,mode=max \
-            -t "${ORG}/${IMAGE}:_build" ./docker
+          context: ./docker
+          file: docker/Dockerfile
+          tags: ${{ env.ORG }}/${{ env.IMAGE }}:_build
+          load: true  # makes the built image available to 'docker' for later steps
+          cache-from: type=gha,scope=${{ env.IMAGE }}
+          cache-to: type=gha,scope=${{ env.IMAGE }},mode=max
 
       - name: Free disk space
         run: |

--- a/.github/workflows/dive.yml
+++ b/.github/workflows/dive.yml
@@ -40,9 +40,22 @@ jobs:
         with:
           tool-cache: true
 
-      - name: Build image
+      - name: Restore BuildKit cache (local dir)
+        uses: actions/cache@v4
+        with:
+          path: /tmp/buildkit-cache
+          key: buildkit-${{ runner.os }}-${{ hashFiles('docker/Dockerfile', 'docker/**') }}
+          restore-keys: |
+            buildkit-${{ runner.os }}-
+
+      - name: Build image and cache layers locally
+        env:
+          DOCKER_BUILDKIT: '1'
         run: |
-          docker build -t ${ORG}/${IMAGE}:_build ./docker/
+          docker build \
+            --cache-from type=local,src=/tmp/buildkit-cache \
+            --cache-to   type=local,dest=/tmp/buildkit-cache,mode=max \
+            -t "${ORG}/${IMAGE}:_build" ./docker
 
       - name: Free disk space
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,6 +28,11 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+
       - name: git checkout dea-sandbox
         uses: actions/checkout@v3
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,7 @@ RUN echo "Enable jupyter lab extensions" \
 SHELL ["/bin/bash", "-euo", "pipefail", "-lc"]
 RUN set -euo pipefail \
     && echo "Enable server extensions" \
+    && df -h; \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "Enable jupyter lab extensions" \
 SHELL ["/bin/bash", "-euo", "pipefail", "-lc"]
 RUN set -euo pipefail \
     && echo "Enable server extensions" \
-    && df -h; \
+    && df -h / /tmp || true \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN set -euo pipefail \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \
-    && jupyter lab build \
+    && jupyter lab build --debug --minimize=false\
     && echo "...done" \
     && APPDIR="$(jupyter lab path | awk -F': ' '/Application directory/ {print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')" \
     && echo "JupyterLab APPDIR=${APPDIR}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,32 +44,39 @@ RUN echo "Enable jupyter lab extensions" \
   && jupyter labextension list \
   && echo "...done"
 
-RUN echo "Enable server extensions" \
-   && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
-   && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
-   && jupyter server extension list \
-   && jupyter lab build \
-   && echo "...done"
-
-# Checks common jupyter lab cache dirs and cleans them up to reclaim space.
+# Enable server extensions and then clean up jupyter lab staging dir to reclaim
+# space in this layer. 
+# Ref: https://github.com/jupyterlab/jupyterlab/blob/main/docs/source/user/directories.md#staging-and-static
 SHELL ["/bin/bash", "-lc"]
-RUN set -euo pipefail; \
-  PY_PREFIX=$(python -c "import sys; print(sys.prefix)"); \
-  LABDIRS=""; \
-  for d in "$PY_PREFIX/share/jupyter/lab" \
-           "/opt/conda/share/jupyter/lab" \
-           "/usr/local/share/jupyter/lab" \
-           "/usr/share/jupyter/lab"; do \
-    [ -d "$d" ] && LABDIRS="$LABDIRS $d"; \
-  done; \
-  [ -z "$LABDIRS" ] && echo "No JupyterLab dirs found" && exit 0; \
-  BEFORE=$(du -sm $LABDIRS | awk '{s+=$1} END {print s}'); \
-  jupyter lab clean || true; \
-  command -v yarn >/dev/null 2>&1 && yarn cache clean --all || true; \
-  command -v npm  >/dev/null 2>&1 && npm  cache clean --force || true; \
-  rm -rf "${HOME}/.cache/yarn" "${HOME}/.npm" || true; \
-  AFTER=$(du -sm $LABDIRS | awk '{s+=$1} END {print s}'); \
-  echo "JupyterLab clean freed $((BEFORE - AFTER)) MB"
+RUN echo "Enable server extensions" \
+    && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
+    && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
+    && jupyter server extension list \
+    && jupyter lab build \
+    && echo "...done" \
+    && APPDIR="$(jupyter lab path | awk -F': ' '/Application directory/ {print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')" \
+    && echo "JupyterLab APPDIR=${APPDIR}" \
+    && [ -n "${APPDIR}" ] || (echo "ERROR: APPDIR is empty"; exit 1) \
+    && mkdir -p "${APPDIR}" \
+    && BEFORE="$(du -sm "${APPDIR}" | awk '{print $1}')" \
+    && STAGING="${APPDIR}/staging" \
+    && if [ -d "${STAGING}" ]; then \
+        echo "Removing staging caches at ${STAGING}"; \
+        rm -rf "${STAGING}/node_modules" \
+                "${STAGING}/.yarn" \
+                "${STAGING}/.cache" \
+                "${STAGING}/build" \
+                "${STAGING}/lib" \
+                "${STAGING}/.pytest_cache" \
+                "${STAGING}/yarn.lock" \
+                "${STAGING}/package-lock.json" \
+                "${STAGING}/pnpm-lock.yaml" || true; \
+        find "${STAGING}" -type f -name '*.map' -delete || true; \
+      else \
+        echo "No staging dir at ${STAGING}; skipping staging cleanup"; \
+      fi \
+    && AFTER="$(du -sm "${APPDIR}" | awk '{print $1}')" \
+    && echo "Preserved production assets in ${APPDIR}. Size before: ${BEFORE} MB, after: ${AFTER} MB"
 
 # Install from unzip instead of conda as conda version is not the tool but an "invoker" 
 RUN echo "Install AWS CLI v2" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN set -euo pipefail \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \
-    && jupyter lab build \
+    && jupyter lab build --minimize=False \
     && echo "...done" \
     && APPDIR="$(jupyter lab path | awk -F': ' '/Application directory/ {print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')" \
     && echo "JupyterLab APPDIR=${APPDIR}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,16 +63,7 @@ RUN set -euo pipefail \
     && STAGING="${APPDIR}/staging" \
     && if [ -d "${STAGING}" ]; then \
         echo "Removing staging caches at ${STAGING}"; \
-        rm -rf "${STAGING:?}/node_modules" \
-                "${STAGING:?}/.yarn" \
-                "${STAGING:?}/.cache" \
-                "${STAGING:?}/build" \
-                "${STAGING:?}/lib" \
-                "${STAGING:?}/.pytest_cache" \
-                "${STAGING:?}/yarn.lock" \
-                "${STAGING:?}/package-lock.json" \
-                "${STAGING:?}/pnpm-lock.yaml" || true; \
-        find "${STAGING}" -type f -name '*.map' -delete || true; \
+        rm -rf "${STAGING:?}" || true; \
       else \
         echo "No staging dir at ${STAGING}; skipping staging cleanup"; \
       fi \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,6 +51,26 @@ RUN echo "Enable server extensions" \
    && jupyter lab build \
    && echo "...done"
 
+# Checks common jupyter lab cache dirs and cleans them up to reclaim space.
+SHELL ["/bin/bash", "-lc"]
+RUN set -euo pipefail; \
+  PY_PREFIX=$(python -c "import sys; print(sys.prefix)"); \
+  LABDIRS=""; \
+  for d in "$PY_PREFIX/share/jupyter/lab" \
+           "/opt/conda/share/jupyter/lab" \
+           "/usr/local/share/jupyter/lab" \
+           "/usr/share/jupyter/lab"; do \
+    [ -d "$d" ] && LABDIRS="$LABDIRS $d"; \
+  done; \
+  [ -z "$LABDIRS" ] && echo "No JupyterLab dirs found" && exit 0; \
+  BEFORE=$(du -sm $LABDIRS | awk '{s+=$1} END {print s}'); \
+  jupyter lab clean || true; \
+  command -v yarn >/dev/null 2>&1 && yarn cache clean --all || true; \
+  command -v npm  >/dev/null 2>&1 && npm  cache clean --force || true; \
+  rm -rf "${HOME}/.cache/yarn" "${HOME}/.npm" || true; \
+  AFTER=$(du -sm $LABDIRS | awk '{s+=$1} END {print s}'); \
+  echo "JupyterLab clean freed $((BEFORE - AFTER)) MB"
+
 # Install from unzip instead of conda as conda version is not the tool but an "invoker" 
 RUN echo "Install AWS CLI v2" \
    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,6 @@ RUN echo "Enable jupyter lab extensions" \
 SHELL ["/bin/bash", "-euo", "pipefail", "-lc"]
 RUN set -euo pipefail \
     && echo "Enable server extensions" \
-    && df -h / /tmp || true \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,8 @@ RUN set -euo pipefail \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \
-    && jupyter lab build --debug --minimize=false\
+    # enable these flags to diagnose lab build issues --debug --minimize=false
+    && jupyter lab build \
     && echo "...done" \
     && APPDIR="$(jupyter lab path | awk -F': ' '/Application directory/ {print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')" \
     && echo "JupyterLab APPDIR=${APPDIR}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,8 @@ RUN echo "Enable jupyter lab extensions" \
 # space in this layer. 
 # Ref: https://github.com/jupyterlab/jupyterlab/blob/main/docs/source/user/directories.md#staging-and-static
 SHELL ["/bin/bash", "-lc"]
-RUN echo "Enable server extensions" \
+RUN set -euo pipefail \
+    && echo "Enable server extensions" \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN set -euo pipefail \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
     && jupyter server extension enable  --py jupyter_resource_usage --sys-prefix \
     && jupyter server extension list \
-    && jupyter lab build --minimize=False \
+    && jupyter lab build \
     && echo "...done" \
     && APPDIR="$(jupyter lab path | awk -F': ' '/Application directory/ {print $2}' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')" \
     && echo "JupyterLab APPDIR=${APPDIR}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN echo "Enable jupyter lab extensions" \
 # Enable server extensions and then clean up jupyter lab staging dir to reclaim
 # space in this layer. 
 # Ref: https://github.com/jupyterlab/jupyterlab/blob/main/docs/source/user/directories.md#staging-and-static
-SHELL ["/bin/bash", "-lc"]
+SHELL ["/bin/bash", "-euo", "pipefail", "-lc"]
 RUN set -euo pipefail \
     && echo "Enable server extensions" \
     && jupyter server extension enable  --py jupyterlab_iframe --sys-prefix \
@@ -63,15 +63,15 @@ RUN set -euo pipefail \
     && STAGING="${APPDIR}/staging" \
     && if [ -d "${STAGING}" ]; then \
         echo "Removing staging caches at ${STAGING}"; \
-        rm -rf "${STAGING}/node_modules" \
-                "${STAGING}/.yarn" \
-                "${STAGING}/.cache" \
-                "${STAGING}/build" \
-                "${STAGING}/lib" \
-                "${STAGING}/.pytest_cache" \
-                "${STAGING}/yarn.lock" \
-                "${STAGING}/package-lock.json" \
-                "${STAGING}/pnpm-lock.yaml" || true; \
+        rm -rf "${STAGING:?}/node_modules" \
+                "${STAGING:?}/.yarn" \
+                "${STAGING:?}/.cache" \
+                "${STAGING:?}/build" \
+                "${STAGING:?}/lib" \
+                "${STAGING:?}/.pytest_cache" \
+                "${STAGING:?}/yarn.lock" \
+                "${STAGING:?}/package-lock.json" \
+                "${STAGING:?}/pnpm-lock.yaml" || true; \
         find "${STAGING}" -type f -name '*.map' -delete || true; \
       else \
         echo "No staging dir at ${STAGING}; skipping staging cleanup"; \

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -216,7 +216,7 @@ dependencies:
   - black
   - python-jose
   - ecdsa
-  - jupyterlab>=4.0
+  - jupyterlab=4.4.10 # Versions >=4.5.2 break jupyter lab extensions build step
   - jupyterlab_code_formatter<3.0 # Non-caught error in >= 3.0
   - jupyterlab-spellchecker
   - jupyterlab-geojson

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -216,7 +216,7 @@ dependencies:
   - black
   - python-jose
   - ecdsa
-  - jupyterlab=4.4.10 # Versions >=4.5.2 break jupyter lab extensions build step
+  - jupyterlab>=4.0
   - jupyterlab_code_formatter<3.0 # Non-caught error in >= 3.0
   - jupyterlab-spellchecker
   - jupyterlab-geojson


### PR DESCRIPTION
This change addresses the the ['Analyse image efficiency](https://github.com/GeoscienceAustralia/dea-sandbox/blob/develop/.github/workflows/dive.yml)' workflow that was failing during the docker build step. 

https://github.com/GeoscienceAustralia/dea-sandbox/actions/runs/20943103364/job/60180532121

When looking at the workflow run output, the layer which installs jupyter lab server extensions was failing to complete. Debug logging showed the GH runner was running out of disk space with only ~180MB free prior to the step.

https://github.com/GeoscienceAustralia/dea-sandbox/actions/runs/21015196451/job/60418827243#step:6:9900

This change introduces a workflow step to clean up the GH runner storage prior to attempting to build the sandbox image. Using this github action: https://github.com/jlumbroso/free-disk-space.

When testing, it successfully cleaned up ~36GB of space.

I also added a check to cleanup jupyter lab's staging directory as this isn't needed once the built assets are copied to its static directory. This results in a further reduction of the sandbox image by ~700MB, which would reduce the image pull time by ~10%.

More info on this can be found here: https://github.com/jupyterlab/jupyterlab/blob/main/docs/source/user/directories.md#staging-and-static

