### PR TITLE
Bump Trivy to Uncompromised Version

### DIFF
--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -44,7 +44,7 @@ jobs:
           docker build -t ${ORG}/${IMAGE}:_build ./docker/
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.35.0
         continue-on-error: true
         with:
           image-ref: '${{ env.ORG }}/${{ env.IMAGE }}:_build'


### PR DESCRIPTION
Trivy has had a security compromise. Versions older than v0.35.0 are pointing to a malicious commit.
https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23


This PR bumps the action to a safe version