### PR TITLE
Update trivy-action release tag to match semver pattern

### DIFF
--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -44,7 +44,7 @@ jobs:
           docker build -t ${ORG}/${IMAGE}:_build ./docker/
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.35.0
         continue-on-error: true
         with:
           image-ref: '${{ env.ORG }}/${{ env.IMAGE }}:_build'


### PR DESCRIPTION
Updated the trivy-action release tag to match github release tags so renovate can track it.