### PR TITLE
Bump sandbox ubuntu jammy image to jammy-20260410

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ ENV CC=/env/bin/x86_64-conda_cos6-linux-gnu-gcc \
 RUN micromamba run -p /env pip install --no-cache-dir \
     --no-build-isolation -r /conf/requirements.txt -c /conf/pip-constraints.txt
 
-FROM ubuntu:jammy-20240212
+FROM ubuntu:jammy-20260410
 
 ARG nb_user=jovyan
 ARG nb_uid=1000


### PR DESCRIPTION
This change bumps up the version of the sandbox base ubuntu image to jammy-20260410.