### PR TITLE
Add step to explicitly install apt packages from a specified list

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ ARG nb_gid=100
 # Each line is <package>=<version>. Comments and blank lines are ignored.
 # To add a new CVE mitigation: edit docker/apt-security.txt and rebuild.
 COPY apt-security.txt /conf/apt-security.txt
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
     && grep -v '^\s*#' /conf/apt-security.txt | grep -v '^\s*$' | \
        xargs apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,9 +29,8 @@ ARG nb_gid=100
 # To add a new CVE mitigation: edit docker/apt-security.txt and rebuild.
 COPY apt-security.txt /conf/apt-security.txt
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update \
-    && grep -v '^\s*#' /conf/apt-security.txt | grep -v '^\s*$' | \
-       xargs apt-get install -y --no-install-recommends \
+RUN packages=$(grep -v '^\s*#' /conf/apt-security.txt | grep -v '^\s*$' | tr '\n' ' ') \
+    && apt-get update && apt-get install -y --no-install-recommends $packages \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,21 @@ ENV CC=/env/bin/x86_64-conda_cos6-linux-gnu-gcc \
 RUN micromamba run -p /env pip install --no-cache-dir \
     --no-build-isolation -r /conf/requirements.txt -c /conf/pip-constraints.txt
 
-FROM ubuntu:jammy-20240212
+FROM ubuntu:jammy-20250415
 
 ARG nb_user=jovyan
 ARG nb_uid=1000
 ARG nb_gid=100
+
+# Apply OS-level security patches declared in apt-security.txt.
+# Each line is <package>=<version>. Comments and blank lines are ignored.
+# To add a new CVE mitigation: edit docker/apt-security.txt and rebuild.
+COPY apt-security.txt /conf/apt-security.txt
+RUN apt-get update \
+    && grep -v '^\s*#' /conf/apt-security.txt | grep -v '^\s*$' | \
+       xargs apt-get install -y --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -l -m -s /bin/bash -N -g $nb_gid -u $nb_uid $nb_user
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,7 @@ ENV CC=/env/bin/x86_64-conda_cos6-linux-gnu-gcc \
 RUN micromamba run -p /env pip install --no-cache-dir \
     --no-build-isolation -r /conf/requirements.txt -c /conf/pip-constraints.txt
 
-FROM ubuntu:jammy-20250415
+FROM ubuntu:jammy-20240212
 
 ARG nb_user=jovyan
 ARG nb_uid=1000

--- a/docker/apt-security.txt
+++ b/docker/apt-security.txt
@@ -1,0 +1,16 @@
+# OS-level security patches applied at image build time.
+# Format: <package>=<version>  (exact apt version string)
+# To find the available version: apt-cache policy <package>
+#
+# When a new CVE mitigation is needed:
+#   1. Add or update the package=version line below
+#   2. Rebuild the image via the normal build and release workflow
+#   3. Document the CVE in the comment above the line
+#
+# When a CVE is resolved in a newer base image (ubuntu:jammy-*), the line
+# can be removed here once the base image tag is bumped past the fix.
+
+# CVE-2026-31431 (Copy Fail) — local privilege escalation via algif_aead kernel module.
+# Fixed in kmod >= 29-1ubuntu1.1. Host kernel must also be patched separately.
+# Ref: https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available
+kmod=29-1ubuntu1.1


### PR DESCRIPTION
Adds a simple package list file used to manually install specific apt packages during the build stage of sandbox image. To be used in cases where CVE's are not yet patched by the base image.