### PR TITLE
Bump pip & conda packages

### DIFF
--- a/docker/locks/conda-linux-64.lock
+++ b/docker/locks/conda-linux-64.lock
@@ -556,7 +556,7 @@ https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad
 https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-15.1.0-h1ac4077_11.conda#8b168842f96f48c156c38078efa6222a
 https://conda.anaconda.org/conda-forge/noarch/pyasn1-0.6.1-pyhd8ed1ab_2.conda#09bb17ed307ad6ab2fd78d32372fdd4e
 https://conda.anaconda.org/conda-forge/noarch/pyasn1-modules-0.4.2-pyhd8ed1ab_0.conda#c689b62552f6b63f32f3322e463f3805
-https://conda.anaconda.org/conda-forge/noarch/pyopenssl-25.1.0-pyhd8ed1ab_0.conda#63d6393b45f33dc0782d73f6d8ae36a0
+https://conda.anaconda.org/conda-forge/noarch/pyopenssl-26.0.0-pyhcf101f3_0.conda#5291776e59082b5244ab973a8fd66e8b
 https://conda.anaconda.org/conda-forge/noarch/pyu2f-0.1.5-pyhd8ed1ab_1.conda#644bd4ca9f68ef536b902685d773d697
 https://conda.anaconda.org/conda-forge/noarch/rsa-4.9.1-pyhd8ed1ab_0.conda#58958bb50f986ac0c46f73b6e290d5fe
 https://conda.anaconda.org/conda-forge/noarch/google-auth-2.40.3-pyhd8ed1ab_0.conda#86fca051b6bf09b7a3a3669bb95f46fa

--- a/docker/locks/conda-linux-64.lock
+++ b/docker/locks/conda-linux-64.lock
@@ -78,7 +78,7 @@ https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb03c661_4.cond
 https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb03c661_4.conda#eaf3fbd2aa97c212336de38a51fe404e
 https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda#37293a85a0f4f77bbd9cf7aaefc62609
 https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py310h7c4b9e2_1.conda#1d54e461bda325196725cdd07ae046cb
-https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.60.0-py310h3406613_0.conda#3f0e123bda4a6794b7b96dfa98b5db23
+https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.61.1-py313h3dea7bd_0.conda#c0f36dfbb130da4f6ce2df31f6b25ea8
 https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.50-h421ea60_1.conda#7af8e91b0deb5f8e25d1a595dea79614
 https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda#8e7251989bca326a28f4a5ffbd74557a
 https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda#f4084e4e6577797150f9b04a4560ceb0

--- a/docker/locks/conda-linux-64.lock
+++ b/docker/locks/conda-linux-64.lock
@@ -19,7 +19,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_5.cond
 https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda#5aa797f8787fe7a17d1b0821485b5adc
 https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda#47e340acb35de30501a76c7c799c41d7
 https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda#74784ee3d225fc3dca89edb635b4e5cc
-https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.3-h26f9b46_0.conda#72b3dd72e4f0b88cdacf3421313480f0
+https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda#da1b85b6a87e141f5140bb9924cecab0
 https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda#283b96675859b20a825f8fa30f311446
 https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda#a0116df4f4ed05c303811a837d5b39d8
 https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda#4222072737ccff51314b5ece9c7d6f5a

--- a/docker/locks/conda-linux-64.lock
+++ b/docker/locks/conda-linux-64.lock
@@ -674,7 +674,7 @@ https://conda.anaconda.org/conda-forge/linux-64/ml_dtypes-0.4.0-py310h5eaa309_2.
 https://conda.anaconda.org/conda-forge/noarch/namex-0.1.0-pyhd8ed1ab_0.conda#3eb854547a0183b994431957fa0e05d2
 https://conda.anaconda.org/conda-forge/linux-64/optree-0.17.0-py310h03d9f68_1.conda#ca5a8a9701dcd6bd0414b6476b6bfda7
 https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda#c41e49bd1f1479bed6c6300038c5466e
-https://conda.anaconda.org/conda-forge/noarch/keras-3.11.2-pyh753f3f9_0.conda#ad0b91bf2bab8992ae5869f0fce16301
+https://conda.anaconda.org/conda-forge/noarch/keras-3.14.1-pyh753f3f9_0.conda#b3d345d389695c26f9f8e06607c7491f
 https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.0-py310hff52083_0.conda#1fe1895d27183b8cb02fa3c2fbdd7cea
 https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyha804496_0.conda#cdd58ab99c214b55d56099108a914282
 https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.4-pyhd8ed1ab_2.conda#d10d9393680734a8febc4b362a4c94f2

--- a/docker/locks/conda-linux-64.lock
+++ b/docker/locks/conda-linux-64.lock
@@ -177,7 +177,7 @@ https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_
 https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py310h89163eb_0.conda#5daf15c40f96f1c2f3721d09e93b66b6
 https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py310h89163eb_0.conda#e768486f2be3f50126bf9a54331221d1
 https://conda.anaconda.org/conda-forge/linux-64/yarl-1.20.1-py310h89163eb_0.conda#3fd5fb648f49ab35899762a567a70699
-https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.12.15-py310h3406613_0.conda#7ba1d3bbcdc4b8f62263ad1aab5eebb6
+https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.13.5-py313hd6074c6_0.conda#d6af03fc1fda940641f409014de8f1fe
 https://conda.anaconda.org/conda-forge/noarch/aioitertools-0.12.0-pyhd8ed1ab_1.conda#3eb47adbffac44483f59e580f8600a1e
 https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_1.conda#972bdca8f30147135f951847b30399ea
 https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.18-pyhd8ed1ab_0.conda#42f86fbce14d7a025ff914cfc7e5450e

--- a/docker/locks/pip-constraints.txt
+++ b/docker/locks/pip-constraints.txt
@@ -69,7 +69,7 @@ contextily==1.6.2
 contourpy==1.3.2
 coverage==7.11.3
 crashtest==0.4.1
-cryptography==46.0.7
+cryptography==45.0.7
 cycler==0.12.1
 Cython==3.1.4
 cytoolz==1.0.1

--- a/docker/locks/pip-constraints.txt
+++ b/docker/locks/pip-constraints.txt
@@ -4,7 +4,7 @@ affine==2.4.0
 ai-edge-litert==2.0.3
 aiobotocore==2.24.2
 aiohappyeyeballs==2.6.1
-aiohttp==3.12.15
+aiohttp==3.13.4
 aioitertools==0.12.0
 aiosignal==1.4.0
 alabaster==1.0.0

--- a/docker/locks/pip-constraints.txt
+++ b/docker/locks/pip-constraints.txt
@@ -69,7 +69,7 @@ contextily==1.6.2
 contourpy==1.3.2
 coverage==7.11.3
 crashtest==0.4.1
-cryptography==45.0.7
+cryptography==46.0.7
 cycler==0.12.1
 Cython==3.1.4
 cytoolz==1.0.1

--- a/docker/locks/pip-constraints.txt
+++ b/docker/locks/pip-constraints.txt
@@ -114,7 +114,7 @@ flask-babel==4.0.0
 flatbuffers==25.2.10
 flox==0.10.4
 folium==0.20.0
-fonttools==4.60.0
+fonttools==4.60.2
 fqdn==1.5.1
 frozenlist==1.7.0
 fsspec==2025.9.0

--- a/docker/locks/pip-constraints.txt
+++ b/docker/locks/pip-constraints.txt
@@ -224,7 +224,7 @@ jupyterlab_theme_toggler==1.1.0
 jupyterlab_topbar_text==1.1.0
 jupyterlab_widgets==3.0.15
 jupytext==1.17.3
-keras==3.11.2
+keras==3.11.3
 keyring==25.6.0
 kiwisolver==1.4.9
 lark==1.2.2

--- a/docker/locks/pip-constraints.txt
+++ b/docker/locks/pip-constraints.txt
@@ -359,7 +359,7 @@ pyerfa==2.0.1.5
 Pygments==2.19.2
 PyJWT==2.10.1
 pyogrio==0.10.0
-pyOpenSSL==25.1.0
+pyOpenSSL==26.0.0
 pyows==0.3.1
 pyparsing==2.4.7
 pyproj==3.7.1


### PR DESCRIPTION
Updates to bump various pip and conda packages to recommended versions.

Conda packages:
openssl 3.5.3 -> 3.6.2
aiohttp-3.12.15 -> 3.13.5
pyopenssl-25.1.0 -> 26.0.0
keras-3.11.2 -> 3.14.1
fonttools-4.60.0 - 4.61.1

Pip packages:
aiohttp 3.12.15 -> 3.13.4
fonttools 4.60.0 -> 4.60.2
keras 3.11.2 -> 3.11.3
pyOpenSSL 25.1.0 -> 26.0.0
