### PR TITLE
Add step to install conda packages specified in env.yaml 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,9 @@ FROM mambaorg/micromamba:git-df79b72-jammy AS sandbox-conda
 
 USER root
 COPY locks/conda-linux-64.lock /conf/
+COPY env.yaml /conf/
 RUN micromamba create  -y -p /env -f /conf/conda-linux-64.lock && \
+    micromamba install -y -p /env -f /conf/env.yaml --no-deps && \
     micromamba clean --all --yes && \
     micromamba env export -p /env --explicit > /conf/conda-linux-64.lock.out
 


### PR DESCRIPTION
This change will install conda packages defined in the env.yaml _after_ the initial conda environment is created (based on its lock files). This allows installation of additional packages (developer intent) when building the image, assumes additional dependencies are present, if not will fail fast. Will prevent version drift and accidental upgrades/downgrades.