### PR TITLE
Bump `dea-tools` to fix interactive app bug

### DIFF
--- a/docker/locks/pip-constraints.txt
+++ b/docker/locks/pip-constraints.txt
@@ -83,7 +83,7 @@ datacube==1.9.10
 datacube_ows==1.9.5
 datadog==0.52.1
 datashader==0.18.2
-dea-tools==0.4.9
+dea-tools==0.4.10
 debugpy==1.8.17
 decorator==5.2.1
 deepdiff==8.6.1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -34,7 +34,7 @@ odc-stac>=0.4.0
 odc-cloud[ASYNC]>=0.2.5
 odc-stats[ows]>=1.9
 odc-ui
-dea-tools>=0.4.9
+dea-tools>=0.4.10
 
 --extra-index-url="https://packages.dea.ga.gov.au"
 thredds-crawler


### PR DESCRIPTION
As approved in CAB 20260515.1, this PR bumps the `dea-tools` version used in DEA Sandbox to fix broken interactive app notebooks.